### PR TITLE
Create command line script for users

### DIFF
--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import vol as v
 
 
@@ -260,18 +261,29 @@ def main():
     # get level info regardless of mode
     get_levels(args, g)
 
+    # get database information
+    db = os.getcwd() + '/' + args.db[0]
+
     # run steps depending on mode
     mode = args.which
-    if mode == 'full':
+    if mode == 'full' or mode == 'visit':
+        # generate isosurfaces
         meshfile = args.meshfile[0]
         dataname = args.dataname[0]
-        # generate isosurfs
+        g.generate_volumes(meshfile, dataname, dbname=db)
+
+    if mode == 'full' or mode == 'moab':
+        e_lower = 0.0  # place holder
+        e_upper = 1.0  # place holder
+
         # create/write geometry
 
-    elif mode == 'visit':
+        #g.create_geometry(e_lower, e_upper, tag_groups=False)
+
+    # elif mode == 'visit':
         # assign/read/gen levels
         # generate isosurfs
-        pass
+    #    pass
     elif mode == 'moab':
         # read/assign levels
         # read database

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -243,7 +243,7 @@ Example usage:
         levels between 0.1 and 1e+14 and specifying where to write the
         generated database:
 
-        generate_isogeom visit -gl log -lx 0.1 1e+14 -db my_database/
+        generate_isogeom visit cw_mesh wwn -gl log -lx 0.1 1e14 -db my_database
 
     (3) Run only the second step (moab mode), using the levelfile and database
         from the MOAB step, and specifying a file name for file produced:

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -361,7 +361,30 @@ mesh file database.
 Levels information must be provided with either the -lf or -lv option.
 """
     moab_usage = 'generate_isogeom moab [-lf/-lv] [OPTIONS]'
-    moab_examples = """ EXAMPLES PLACEHOLDER """
+    moab_examples = """
+Example Usage:
+    (1) Create an isosurface geometry called 'my_isogeom.h5m' with assigned
+        level values of 0.1 0.4 and 1.0, and tag the surfaces with data for
+        vizualization (assume default database location):
+
+        generate_isogeom moab -lv 0.1 0.4 1.0 -g my_isogeom.h5m --viz
+
+    (2) Generate a geometry from a database located in 'my_isogeom/', read the
+        level info from a file called 'levelinfo', mutliply all data by a
+        factor of 2e4, and save the file as 'my_isogeom.vtk' in a new folder
+        called 'output_folder/':
+
+        generate_isogeom moab -db my_isogeom/ -lf levelinfo -n 2e4
+            -g my_isogeom.vtk -sp output_folder/
+
+    (3) Generate a geometry from a database in the default location, read
+        levels from a file called 'levelfile' located in the database, tag the
+        geometry two metadata tags called E1 and E2 with values of 1.0 and
+        10.0, respectively, and tag the geometry with the level information for
+        vizualization:
+
+        generate_isogeom moab -lf tmp/levelfile -t E1 1.0 -t E2 10.0 -v
+    """
     moab_parser = subparsers.add_parser('moab',
                                         description=moab_description,
                                         usage=moab_usage,

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -81,19 +81,20 @@ def set_level_options(parser, moab):
 def set_visit_only_options(parser):
     """set options specific to the Visit step.
     """
-    parser.add_argument('FILENAME',
+    parser.add_argument('meshfile',
         action = 'store',
         nargs = 1,
         type = str,
-        help = 'Relative path to the Cartesian mesh file (VTK) that will be used to generate isosurfaces.'
+        help = 'Relative path to the Cartesian mesh file (vtk format) that will be used to generate isosurfaces.'
         )
 
-    parser.add_argument('DATA',
+    parser.add_argument('dataname',
         action = 'store',
         nargs = 1,
         type = str,
-        help = 'String representing the name of the data on the Cartesian mesh file to use for the isosurfaces.'
+        help = 'String representing the name of the scalar data on the Cartesian mesh file to use for the isosurfaces.'
         )
+
 
 def set_moab_only_options(parser):
     """Set options specific to the MOAB step
@@ -103,7 +104,7 @@ def set_moab_only_options(parser):
         nargs = 1,
         required = False,
         default = 1e-5,
-        metavar = 'MERGE_TOL',
+        metavar = 'TOL',
         dest = 'mergetol',
         type = float,
         help = 'Merge tolerance for mesh based merging of coincident surfaces. Default=1e-5.'
@@ -205,16 +206,20 @@ def parse_arguments():
     set_visit_only_options(full_parser)
     set_shared_options(full_parser)
     set_moab_only_options(full_parser)
+    full_parser.set_defaults(which='full')
 
     # set visit only mode options
     visit_parser = subparsers.add_parser('visit', help = 'Only generate the isosurface mesh files using VisIt.')
     set_visit_only_options(visit_parser)
     set_shared_options(visit_parser)
+    visit_parser.set_defaults(which='visit')
 
     # set moab only mode options
     moab_parser = subparsers.add_parser('moab', help = 'Only generate the geometry with MOAB starting from the VisIt mesh files.')
     set_shared_options(moab_parser, moab=True)
     set_moab_only_options(moab_parser)
+    moab_parser.set_defaults(which='moab')
+
     args = parser.parse_args()
 
     return args

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -216,7 +216,12 @@ def set_shared_options(parser, moab=False):
 
 
 def parse_arguments():
-    """Parse user args"""
+    """Parse user args
+
+    There are three subparsers, one for each mode: full, visit, and moab.
+    Full mode runs both the visit and moab steps. Each parser should have a
+    full help message, simplified usage statement, and examples.
+    """
     mode_examples = """
 To view full options for each mode, use 'generate_isogeom MODE -h'.\n
 
@@ -236,7 +241,8 @@ Example usage:
     (3) Run only the second step (moab mode), using the levelfile and database
         from the MOAB step, and specifying a file name for file produced:
 
-        generate_isogeom moab -lf my_database/levelfile -db my_database -g geom1.h5m
+        generate_isogeom moab -lf my_database/levelfile -db my_database \
+            -g geom1.h5m
 """
 
     mode_description = """
@@ -272,7 +278,28 @@ provided.
 """
     full_usage = \
         'generate_isogeom full [-lf/-lv/-gl] [OPTIONS] meshfile dataname'
-    full_examples = """ EXAMPLES PLACEHOLDER """
+    full_examples = """
+Example Usage:
+    (1) Create an isosurface geometry called 'my_isogeom.h5m' with assigned
+        level values of 0.1 0.4 and 1.0, and tag the surfaces with data for
+        vizualization:
+
+        generate_isogeom full meshfile my_data -lv 0.1 0.4 1.0
+            -g my_isogeom.h5m --viz
+
+    (2) Generate a geometry with 5 levels lograthmically spaced from 1e-5 and
+        1e+3. Also tag the geometry two metadata tags called E1 and E2 with
+        values of 1.0 and 10.0, respectively:
+
+        generate_isogeom full meshfile my_data -gl log -lx 1e-5 1e+3 -N 5
+            -t E1 1.0 -t E2 10.0
+
+    (3) Store the generated database in a different folder called 'my_isogeom/'
+        and read level information from a file called 'levelfile' located in
+        the current directory:
+
+        generate_isogeom full meshfile my_data -lf levelfile -db my_isogeom/
+    """
 
     full_parser = subparsers.add_parser('full',
                                         description=full_description,

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -143,11 +143,22 @@ def set_moab_only_options(parser):
                         metavar='GEOM_FILENAME',
                         dest='geomfile',
                         type=str,
-                        help='Filename and relative path to write generated ' +
-                        'isosurface geometry file. ' +
+                        help='Filename to write generated isosurface ' +
+                        'geometry file. ' +
                         'Must be either a .h5m or .vtk file name. ' +
-                        'Default name is isogeom.h5m in the database ' +
-                        'location (-db).'
+                        'Default name is isogeom.h5m.'
+                        )
+    parser.add_argument('-sp', '--savepath',
+                        action='store',
+                        nargs=1,
+                        required=False,
+                        default=None,
+                        metavar='PATH',
+                        dest='savepath',
+                        type=str,
+                        help='Absolue path to folder to write generated ' +
+                        'geometry file. If not set, file will be saved in ' +
+                        'the database folder (-db).'
                         )
     parser.add_argument('-t', '--tag',
                         action='append',
@@ -312,7 +323,9 @@ def main():
                           norm=args.norm[0],
                           merg_tol=args.merg_tol[0],
                           tags=tags,
-                          dbname=db)
+                          dbname=db,
+                          sname=args.geomfile[0],
+                          sdir=args.savepath[0])
 
 
 if __name__ == "__main__":

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -149,6 +149,19 @@ def set_moab_only_options(parser):
                         'Default name is isogeom.h5m in the database ' +
                         'location (-db).'
                         )
+    parser.add_argument('-t', '--tag',
+                        action='append',
+                        nargs=2,
+                        required=False,
+                        default=None,
+                        metavar='TAGNAME TAGVAL',
+                        dest='tags',
+                        help='Information to tag on the whole geometry. ' +
+                        'First entry must be the name for the tag (string). ' +
+                        'Second entry must be the value for the tag (will ' +
+                        'be tagged as float). ' +
+                        'Option can be set more than once to set more tags.'
+                        )
 
 
 def set_shared_options(parser, moab=False):
@@ -244,6 +257,27 @@ def get_levels(args, g):
                            "recognized")
 
 
+def process_tags(tags):
+    """Convert the provided tag information to a dictionary to pass to the
+    geometry creation stepself.
+
+    Input:
+    -----
+        tags: list of lists, [[tagname1, tagval1], [tagname2, tagval2], ...]
+
+    Return:
+    -------
+        tagdict: dict, key=TAGNAME, value=TAGVALUE
+    """
+    tagdict = {}
+    for tagset in tags:
+        key = tagset[0]
+        val = float(tagset[1])
+        tagdict[key] = val
+
+    return tagdict
+
+
 def main():
 
     # get args
@@ -268,12 +302,13 @@ def main():
         g.generate_volumes(meshfile, dataname, dbname=db)
 
     if mode == 'full' or mode == 'moab':
-        e_lower = 0.0  # place holder
-        e_upper = 1.0  # place holder
+        if args.tags is not None:
+            tags = process_tags(args.tags)
+        else:
+            tags = None
 
         # create/write geometry
-
-        #g.create_geometry(e_lower, e_upper, tag_groups=False)
+        # g.create_geometry(e_lower, e_upper, tag_groups=False)
 
     # elif mode == 'visit':
         # assign/read/gen levels

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -239,7 +239,7 @@ Example usage:
         generate_isogeom moab -lf my_database/levelfile -db my_database -g geom1.h5m
 """
 
-    description = """
+    mode_description = """
 Use this to generate a full isosurface geometry from a starting Cartesian mesh
 file containing scalar data using VisIt and MOAB. This tool can be run in three
 different modes:
@@ -253,7 +253,7 @@ different modes:
         the visit step.
 """
 
-    parser = argparse.ArgumentParser(description=description,
+    parser = argparse.ArgumentParser(description=mode_description,
                                      usage='generate_isogeom MODE [OPTIONS]',
                                      epilog=mode_examples,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -262,9 +262,14 @@ different modes:
                                        'generating the geometry.')
 
     # set full mode options
-    full_parser = subparsers.add_parser('full', help='Start-to-finish ' +
-                                        'generation from a Cartesian mesh ' +
-                                        'file to a DAGMC-compliant geometry.')
+    full_description = """
+Start-to-finish generation from a Cartesian mesh file to a DAGMC-compliant
+geometry."""
+    full_usage = \
+        'generate_isogeom full [-lf/-lv/-gl] [OPTIONS] meshfile dataname'
+
+    full_parser = subparsers.add_parser('full', description=full_description,
+                                        usage=full_usage)
     set_visit_only_options(full_parser)
     set_shared_options(full_parser)
     set_moab_only_options(full_parser)

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -321,7 +321,29 @@ provided.
 """
     visit_usage = \
         'generate_isogeom visit [-lf/-lv/-gl] [OPTIONS] meshfile dataname'
-    visit_examples = """ EXAMPLES PLACEHOLDER """
+    visit_examples = """
+Example Usage:
+    (1) Generate a database located at 'my_database/' with assigned
+        level values of 0.1 0.4 and 1.0:
+
+        generate_isogeom visit meshfile my_data -lv 0.1 0.4 1.0
+            -db my_isogeom/
+
+    (2) Generate a database in the default location using levels between 1.0
+        2e+4 that are spaced with a ratio of 20:
+
+        generate_isogeom visit meshfile my_data -gl ratio -lx 1.0 2.e4 -N 20
+
+    (3) Generate a database in the default location using 15 levels between 1.0
+        2e+4 that are spaced logarithmically:
+
+        generate_isogeom visit meshfile my_data -gl log -lx 1.0 2.e4 -N 15
+
+    (4) Generate a database in a folder called 'my_isogeom/' and read the level
+        information from a file in the current directory called 'levelfile':
+
+        generate_isogeom visit meshfile my_data -lf levelfile -db my_isogeom/
+    """
     visit_parser = subparsers.add_parser('visit',
                                          description=visit_description,
                                          usage=visit_usage,

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -264,28 +264,60 @@ different modes:
     # set full mode options
     full_description = """
 Start-to-finish generation from a Cartesian mesh file to a DAGMC-compliant
-geometry."""
+geometry.
+
+Levels information must be provided with either the -lf, -lv, or -gl option.
+If using the -gl option (generate levels), then options -lx and -N must also be
+provided.
+"""
     full_usage = \
         'generate_isogeom full [-lf/-lv/-gl] [OPTIONS] meshfile dataname'
+    full_examples = """ EXAMPLES PLACEHOLDER """
 
-    full_parser = subparsers.add_parser('full', description=full_description,
-                                        usage=full_usage)
+    full_parser = subparsers.add_parser('full',
+                                        description=full_description,
+                                        usage=full_usage,
+                                        epilog=full_examples,
+                                        formatter_class=argparse.RawDescriptionHelpFormatter)
     set_visit_only_options(full_parser)
     set_shared_options(full_parser)
     set_moab_only_options(full_parser)
     full_parser.set_defaults(which='full')
 
     # set visit only mode options
-    visit_parser = subparsers.add_parser('visit', help='Only generate the ' +
-                                         'isosurface mesh files using VisIt.')
+    visit_description = """
+Only generate the isosurface mesh file database using VisIt.
+
+Levels information must be provided with either the -lf, -lv, or -gl option.
+If using the -gl option (generate levels), then options -lx and -N must also be
+provided.
+"""
+    visit_usage = \
+        'generate_isogeom visit [-lf/-lv/-gl] [OPTIONS] meshfile dataname'
+    visit_examples = """ EXAMPLES PLACEHOLDER """
+    visit_parser = subparsers.add_parser('visit',
+                                         description=visit_description,
+                                         usage=visit_usage,
+                                         epilog=visit_examples,
+                                         formatter_class=argparse.RawDescriptionHelpFormatter)
     set_visit_only_options(visit_parser)
     set_shared_options(visit_parser)
     visit_parser.set_defaults(which='visit')
 
     # set moab only mode options
-    moab_parser = subparsers.add_parser('moab', help='Only generate the ' +
-                                        'DAGMC-compliant geometry with MOAB ' +
-                                        'starting from the VisIt mesh files.')
+    moab_description = """
+Only generate the DAGMC-compliant geometry with MOAB starting from the VisIt
+mesh file database.
+
+Levels information must be provided with either the -lf or -lv option.
+"""
+    moab_usage = 'generate_isogeom moab [-lf/-lv] [OPTIONS]'
+    moab_examples = """ EXAMPLES PLACEHOLDER """
+    moab_parser = subparsers.add_parser('moab',
+                                        description=moab_description,
+                                        usage=moab_usage,
+                                        epilog=moab_examples,
+                                        formatter_class=argparse.RawDescriptionHelpFormatter)
     set_shared_options(moab_parser, moab=True)
     set_moab_only_options(moab_parser)
     moab_parser.set_defaults(which='moab')

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -217,10 +217,47 @@ def set_shared_options(parser, moab=False):
 
 def parse_arguments():
     """Parse user args"""
-    parser = argparse.ArgumentParser(description='Generate isosurface ' +
-                                     'geometry from a Cartesian mesh file ' +
-                                     'with VisIt and MOAB')
-    subparsers = parser.add_subparsers(title='Run Steps',
+    mode_examples = """
+To view full options for each mode, use 'generate_isogeom MODE -h'.\n
+
+Example usage:
+    (1) Run all the steps start to finish (full mode) starting with meshfile
+        'cw_mesh', scalar data 'wwn', and defining 3 values for the level
+        information at runtime:
+
+        generate_isogeom full cw_mesh wwn -lv 0.1 5.2 12.3
+
+    (2) Run just the first step (visit mode), generating logarithmically spaced
+        levels between 0.1 and 1e+14 and specifying where to write the
+        generated database:
+
+        generate_isogeom visit -gl log -lx 0.1 1e+14 -db my_database/
+
+    (3) Run only the second step (moab mode), using the levelfile and database
+        from the MOAB step, and specifying a file name for file produced:
+
+        generate_isogeom moab -lf my_database/levelfile -db my_database -g geom1.h5m
+"""
+
+    description = """
+Use this to generate a full isosurface geometry from a starting Cartesian mesh
+file containing scalar data using VisIt and MOAB. This tool can be run in three
+different modes:
+    full: run both steps starting from the Cartesian mesh file to produce
+        a full DAGMC-compliant isosurface geom. This step first runs the visit
+        step then the moab step.
+    visit: run only the first step using VisIt. This will generate a database
+        of individual mesh isosurfaces from the Cartesian mesh fileself.
+    moab: run only the second step using MOAB. This will generate a full DAGMC-
+        compliant isosurface geometry starting from the database generated from
+        the visit step.
+"""
+
+    parser = argparse.ArgumentParser(description=description,
+                                     usage='generate_isogeom MODE [OPTIONS]',
+                                     epilog=mode_examples,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    subparsers = parser.add_subparsers(title='Modes',
                                        help='Select which steps to run for ' +
                                        'generating the geometry.')
 

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -393,7 +393,6 @@ def main():
 
     # get args
     args = parse_arguments()
-    print(args)
 
     # create instance
     g = v.IsoVolume()

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -2,6 +2,13 @@ import argparse
 import os
 import vol as v
 
+"""This is a script that can be installed for a user to easily run all the
+steps to create an isosurface geometry from a mesh file with scalar data from
+the command line. This script will parse the command line options and call the
+necessary methods from the vol.py file. There are three modes for running this
+script: full, visit, and moab. Each are documented below.
+"""
+
 
 def set_level_options(parser, moab):
     """Sets options for specifying level values.

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -194,6 +194,7 @@ def set_shared_options(parser, moab=False):
             'Default is a folder named tmp/ in the current directory.'
         )
 
+
 def parse_arguments():
     """parse user args
     """
@@ -224,10 +225,30 @@ def parse_arguments():
 
     return args
 
+
 def main():
 
+    # get args
     args = parse_arguments()
 
+    # run steps depending on mode
+    mode = args.which
+    if mode == 'full':
+        # assign/read/gen levels
+        # generate isosurfs
+        # create/write geometry
+        pass
+    elif mode == 'visit':
+        # assign/read/gen levels
+        # generate isosurfs
+        pass
+    elif mode == 'moab':
+        # read/assign levels
+        # read database
+        # generate geometry
+        pass
+    else:
+        raise RuntimeError("Run mode not recognized.")
 
 if __name__ == "__main__":
     main()

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -66,7 +66,7 @@ def set_level_options(parser, moab):
                             nargs=2,
                             required=False,
                             default=None,
-                            metavar='MIN_VAL MAX_VAL',
+                            metavar=('MIN_VAL', 'MAX_VAL'),
                             dest='extN',
                             type=float,
                             help='float, minimum and maximum values to use ' +
@@ -181,7 +181,7 @@ def set_moab_only_options(parser):
                         nargs=2,
                         required=False,
                         default=None,
-                        metavar='TAGNAME TAGVAL',
+                        metavar=('TAGNAME', 'TAGVAL'),
                         dest='tags',
                         help='Information to tag on the whole geometry. ' +
                         'First entry must be the name for the tag (string). ' +

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -177,7 +177,7 @@ def parse_arguments():
                                      'geometry from a Cartesian mesh file ' +
                                      'with VisIt and MOAB')
     subparsers = parser.add_subparsers(title='Run Steps',
-                                       help="Select which steps to run for ' +
+                                       help='Select which steps to run for ' +
                                        'generating the geometry.')
 
     # set full mode options
@@ -217,6 +217,7 @@ def main():
     # run steps depending on mode
     mode = args.which
     if mode == 'full':
+
         # assign/read/gen levels
         # generate isosurfs
         # create/write geometry

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -308,19 +308,11 @@ def main():
             tags = None
 
         # create/write geometry
-        # g.create_geometry(e_lower, e_upper, tag_groups=False)
-
-    # elif mode == 'visit':
-        # assign/read/gen levels
-        # generate isosurfs
-    #    pass
-    elif mode == 'moab':
-        # read/assign levels
-        # read database
-        # generate geometry
-        pass
-    else:
-        raise RuntimeError("Run mode not recognized.")
+        g.create_geometry(tag_for_viz=args.tagviz[0],
+                          norm=args.norm[0],
+                          merg_tol=args.merg_tol[0],
+                          tags=tags,
+                          db=db)
 
 
 if __name__ == "__main__":

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -286,8 +286,7 @@ def get_levels(args, g):
         check_level_gen(args)
         minN = min(args.extN)
         maxN = max(args.extN)
-        N = args.N[0]
-        g.generate_levels(N, minN, maxN, mode=args.generatelevels[0])
+        g.generate_levels(args.N[0], minN, maxN, mode=args.generatelevels[0])
     else:
         raise RuntimeError("Mode for setting level information is not " +
                            "recognized")
@@ -335,9 +334,7 @@ def main():
     mode = args.which
     if mode == 'full' or mode == 'visit':
         # generate isosurfaces
-        meshfile = args.meshfile[0]
-        dataname = args.dataname[0]
-        g.generate_volumes(meshfile, dataname, dbname=db)
+        g.generate_volumes(args.meshfile[0], args.dataname[0], db)
 
     if mode == 'full' or mode == 'moab':
         if args.tags is not None:

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -225,8 +225,14 @@ def get_levels(args, g):
         g: IsoVolume instance
     """
     # collect level information:
-    if args.generatelevels is not None:
-        # option 1: generate levels
+    if args.levelfile is not None:
+        # option 1: read from file
+        g.read_levels(args.levelfile[0])
+    elif args.levelvalues is not None:
+        # option 2: set values at run time
+        g.assign_levels(args.levelvalues)
+    elif args.generatelevels is not None:
+        # option 3: generate levels
         check_level_gen(args)
         minN = min(args.extN)
         maxN = max(args.extN)
@@ -237,12 +243,6 @@ def get_levels(args, g):
             g.generate_levels(N, minN, maxN, log=False, ratio=False)
         elif args.generatelevels[0] == 'log':
             g.generate_levels(N, minN, maxN, log=True, ratio=False)
-    elif args.levelfile is not None:
-        # option 2: read from file
-        g.read_levels(args.levelfile[0])
-    elif args.levelvalues is not None:
-        # option 3: set values at run time
-        g.assign_levels(args.levelvalues)
     else:
         raise RuntimeError("Mode for setting level information is not " +
                            "recognized")
@@ -254,13 +254,15 @@ def main():
     args = parse_arguments()
     print(args)
 
+    # create instance
     g = v.IsoVolume()
+
+    # get level info regardless of mode
+    get_levels(args, g)
 
     # run steps depending on mode
     mode = args.which
-
     if mode == 'full':
-        get_levels(args, g)
         meshfile = args.meshfile[0]
         dataname = args.dataname[0]
         # generate isosurfs

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -238,12 +238,7 @@ def get_levels(args, g):
         minN = min(args.extN)
         maxN = max(args.extN)
         N = args.N[0]
-        if args.generatelevels[0] == 'ratio':
-            g.generate_levels(N, minN, maxN, log=False, ratio=True)
-        elif args.generatelevels[0] == 'lin':
-            g.generate_levels(N, minN, maxN, log=False, ratio=False)
-        elif args.generatelevels[0] == 'log':
-            g.generate_levels(N, minN, maxN, log=True, ratio=False)
+        g.generate_levels(N, minN, maxN, mode=args.generatelevels[0])
     else:
         raise RuntimeError("Mode for setting level information is not " +
                            "recognized")

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -1,26 +1,30 @@
 import argparse
 import vol as v
 
+
 def set_level_options(parser, moab):
     """Sets options for specifying level values. If moab mode, do not
     give options for generating levels.
     """
     level_group = parser.add_mutually_exclusive_group(required=True)
     level_group.add_argument('-lf', '--levelfile',
-        action = 'store',
-        nargs = 1,
-        type = str,
-        help = 'Relative path to file containing values to use for the isosurface levels. ' +\
-            'File should be structured to have one value per line.'
-        )
+                                    action='store',
+                                    nargs=1,
+                                    type=str,
+                                    help='Relative path to file containing ' +
+                                    'values to use for isosurface levels.' +
+                                    'File should be structured to have one ' +
+                                    'value per line.'
+                             )
     level_group.add_argument('-lv', '--levelvalues',
-        action = 'store',
-        nargs = '+',
-        default = None,
-        metavar = 'VAL',
-        type = float,
-        help = 'List of values used to generate isosurfaces in VisIt.'
-        )
+                                    action='store',
+                                    nargs='+',
+                                    default=None,
+                                    metavar='VAL',
+                                    type=float,
+                                    help='List of values used to generate ' +
+                                    'isosurfaces in VisIt.'
+                             )
 
     # only have option to generate levels if not moab mode
     if not moab:

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -254,5 +254,6 @@ def main():
     else:
         raise RuntimeError("Run mode not recognized.")
 
+
 if __name__ == "__main__":
     main()

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -2,7 +2,9 @@ import argparse
 import vol as v
 
 def set_level_options(parser, moab):
-    # information for setting levels
+    """Sets options for specifying level values. If moab mode, do not
+    give options for generating levels.
+    """
     level_group = parser.add_mutually_exclusive_group(required=True)
     level_group.add_argument('-lf', '--levelfile',
         action = 'store',
@@ -77,6 +79,8 @@ def set_level_options(parser, moab):
 
 
 def set_visit_only_options(parser):
+    """set options specific to the Visit step.
+    """
     parser.add_argument('FILENAME',
         action = 'store',
         nargs = 1,
@@ -92,6 +96,8 @@ def set_visit_only_options(parser):
         )
 
 def set_moab_only_options(parser):
+    """Set options specific to the MOAB step
+    """
     parser.add_argument('-m', '--mergetol',
         action = 'store',
         nargs = 1,
@@ -172,9 +178,9 @@ def set_moab_only_options(parser):
         )
 
 def set_shared_options(parser, moab=False):
-
+    """set options that are in both the moab and visit steps.
+    """
     set_level_options(parser, moab)
-
     parser.add_argument('-db', '--database',
         action = 'store',
         nargs = 1,

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -223,7 +223,7 @@ def parse_arguments():
     full help message, simplified usage statement, and examples.
     """
     mode_examples = """
-To view full options for each mode, use 'generate_isogeom MODE -h'.\n
+To view full options for each mode, use 'generate_isogeom MODE -h'.
 
 Example usage:
     (1) Run all the steps start to finish (full mode) starting with meshfile
@@ -241,10 +241,9 @@ Example usage:
     (3) Run only the second step (moab mode), using the levelfile and database
         from the MOAB step, and specifying a file name for file produced:
 
-        generate_isogeom moab -lf my_database/levelfile -db my_database \
+        generate_isogeom moab -lf my_database/levelfile -db my_database
             -g geom1.h5m
 """
-
     mode_description = """
 Use this to generate a full isosurface geometry from a starting Cartesian mesh
 file containing scalar data using VisIt and MOAB. This tool can be run in three
@@ -258,7 +257,6 @@ different modes:
         compliant isosurface geometry starting from the database generated from
         the visit step.
 """
-
     parser = argparse.ArgumentParser(description=mode_description,
                                      usage='generate_isogeom MODE [OPTIONS]',
                                      epilog=mode_examples,
@@ -277,7 +275,7 @@ If using the -gl option (generate levels), then options -lx and -N must also be
 provided.
 """
     full_usage = \
-        'generate_isogeom full [-lf/-lv/-gl] [OPTIONS] meshfile dataname'
+        'generate_isogeom full meshfile dataname [-lf/-lv/-gl] [OPTIONS]'
     full_examples = """
 Example Usage:
     (1) Create an isosurface geometry called 'my_isogeom.h5m' with assigned
@@ -300,7 +298,6 @@ Example Usage:
 
         generate_isogeom full meshfile my_data -lf levelfile -db my_isogeom/
     """
-
     full_parser = subparsers.add_parser('full',
                                         description=full_description,
                                         usage=full_usage,
@@ -320,7 +317,7 @@ If using the -gl option (generate levels), then options -lx and -N must also be
 provided.
 """
     visit_usage = \
-        'generate_isogeom visit [-lf/-lv/-gl] [OPTIONS] meshfile dataname'
+        'generate_isogeom visit meshfile dataname [-lf/-lv/-gl] [OPTIONS]'
     visit_examples = """
 Example Usage:
     (1) Generate a database located at 'my_database/' with assigned

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -8,219 +8,198 @@ def set_level_options(parser, moab):
     """
     level_group = parser.add_mutually_exclusive_group(required=True)
     level_group.add_argument('-lf', '--levelfile',
-                                    action='store',
-                                    nargs=1,
-                                    type=str,
-                                    help='Relative path to file containing ' +
-                                    'values to use for isosurface levels.' +
-                                    'File should be structured to have one ' +
-                                    'value per line.'
+                             action='store',
+                             nargs=1,
+                             type=str,
+                             help='Relative path to file containing values ' +
+                             'to use for isosurface levels. '
+                             'File should be structured to have one value ' +
+                             'per line.'
                              )
     level_group.add_argument('-lv', '--levelvalues',
-                                    action='store',
-                                    nargs='+',
-                                    default=None,
-                                    metavar='VAL',
-                                    type=float,
-                                    help='List of values used to generate ' +
-                                    'isosurfaces in VisIt.'
+                             action='store',
+                             nargs='+',
+                             default=None,
+                             metavar='VAL',
+                             type=float,
+                             help='List of values used to generate ' +
+                             'isosurfaces in VisIt.'
                              )
 
     # only have option to generate levels if not moab mode
     if not moab:
         level_group.add_argument('-gl', '--generatelevels',
-            action = 'store',
-            nargs = 1,
-            choices = ['ratio', 'log', 'lin'],
-            default = 'lin',
-            metavar = 'ratio/log/lin',
-            type = str,
-            help = 'Specifies the mode for generating level values to be used for the isosurfaces. ' +\
-                'If used, values for the min level (-lmin), max level (-lmax), and the ratio or number of levels (-N) are also required. ' +\
-                'Options are ' +\
-                '(1) ratio: N is the ratio between levels ranging from the min value upto, but not exceeding, the max value. ' +\
-                '(2) log: N is the number of levels to be evenly spaced logarithmically between the min and max values. ' +\
-                '(3) lin: N is the number of levels to be evenly spaced linearly between the min and max values.'
-            )
-        parser.add_argument('-lmin', '--levelmin',
-            action = 'store',
-            nargs = 1,
-            required = False,
-            default = None,
-            metavar = 'MIN_VAL',
-            dest = 'minN',
-            type = float,
-            help = 'float, minimum value to use for generating set ' +\
-                'of level values to be used for the isosurfaces. ' +\
-                'Only required if generating levels for full mode or visit-only mode. ' +\
-                'If used, must also provide a maximum value (-lmax).'
-            )
-        parser.add_argument('-lmax', '--levelmax',
-            action = 'store',
-            nargs = 1,
-            required = False,
-            default = None,
-            metavar = 'MAX_VAL',
-            dest = 'maxN',
-            type = float,
-            help = 'float, maximum value to use for generating set ' +\
-                'of level values to be used for the isosurfaces. ' +\
-                'Only required if generating levels for full mode or visit-only mode. ' +\
-                'If used, must also provide a minimum value (-lmin).'
-            )
+                                 action='store',
+                                 nargs=1,
+                                 choices=['ratio', 'log', 'lin'],
+                                 default='lin',
+                                 metavar='ratio/log/lin',
+                                 type=str,
+                                 help='Specifies the mode for generating ' +
+                                 'level values to be used for the ' +
+                                 'isosurfaces. '
+                                 'If used, values for the minimum and ' +
+                                 'maximum levels (-lex) and the ratio or ' +
+                                 'number of levels (-N) are also required. ' +
+                                 'Options are: ' +
+                                 '(1) ratio: N is the ratio between levels ' +
+                                 'ranging from the min value upto, but not ' +
+                                 'exceeding, the max value. ' +
+                                 '(2) log: N is the number of levels to be ' +
+                                 'evenly spaced logarithmically between the ' +
+                                 'min and max values. ' +
+                                 '(3) lin: N is the number of levels to be ' +
+                                 'evenly spaced linearly between the min ' +
+                                 'and max values.'
+                                 )
+        parser.add_argument('-lx', '--levelextrema',
+                            action='store',
+                            nargs=2,
+                            required=False,
+                            default=None,
+                            metavar='MIN_VAL MAX_VAL',
+                            dest='extN',
+                            type=float,
+                            help='float, minimum and maximum values to use ' +
+                            'for generating the set of level values to be ' +
+                            'used for the isosurfaces.'
+                            )
         parser.add_argument('-N', '--numlevels',
-            action = 'store',
-            nargs = 1,
-            required = False,
-            default = None,
-            metavar = 'N',
-            dest = 'N',
-            type = float,
-            help = 'If generating levels (-gl), it is either ' +\
-                'the ratio between adjacent level values (ratio mode), ' +\
-                'or the number of levels to generate (log or lin mode).'
-            )
+                            action='store',
+                            nargs=1,
+                            required=False,
+                            default=None,
+                            metavar='N',
+                            dest='N',
+                            type=float,
+                            help='If generating levels (-gl), it is either ' +
+                            'the ratio between adjacent level values (ratio ' +
+                            'mode), or the number of levels to generate ' +
+                            '(log or lin mode).'
+                            )
 
 
 def set_visit_only_options(parser):
     """set options specific to the Visit step.
     """
     parser.add_argument('meshfile',
-        action = 'store',
-        nargs = 1,
-        type = str,
-        help = 'Relative path to the Cartesian mesh file (vtk format) that will be used to generate isosurfaces.'
-        )
-
+                        action='store',
+                        nargs=1,
+                        type=str,
+                        help='Relative path to the Cartesian mesh file ' +
+                        '(vtk format) that will be used to generate ' +
+                        'isosurfaces.'
+                        )
     parser.add_argument('dataname',
-        action = 'store',
-        nargs = 1,
-        type = str,
-        help = 'String representing the name of the scalar data on the Cartesian mesh file to use for the isosurfaces.'
-        )
+                        action='store',
+                        nargs=1,
+                        type=str,
+                        help='String representing the name of the scalar ' +
+                        'data on the Cartesian mesh file to use for the ' +
+                        'isosurfaces.'
+                        )
 
 
 def set_moab_only_options(parser):
     """Set options specific to the MOAB step
     """
     parser.add_argument('-m', '--mergetol',
-        action = 'store',
-        nargs = 1,
-        required = False,
-        default = 1e-5,
-        metavar = 'TOL',
-        dest = 'mergetol',
-        type = float,
-        help = 'Merge tolerance for mesh based merging of coincident surfaces. Default=1e-5.'
-        )
+                        action='store',
+                        nargs=1,
+                        required=False,
+                        default=1e-5,
+                        metavar='TOL',
+                        dest='mergetol',
+                        type=float,
+                        help='Merge tolerance for mesh based merging of ' +
+                        'coincident surfaces. Default=1e-5.'
+                        )
     parser.add_argument('-n', '--norm',
-        action = 'store',
-        nargs = 1,
-        required = False,
-        default = 1,
-        metavar = 'NORM_FACTOR',
-        dest = 'norm',
-        type = float,
-        help = 'All level values will be multiplied by this normalization factor ' +\
-            'when the geometry is generated. Default=1'
-        )
+                        action='store',
+                        nargs=1,
+                        required=False,
+                        default=1,
+                        metavar='NORM_FACTOR',
+                        dest='norm',
+                        type=float,
+                        help='All level values will be multiplied by this ' +
+                        'normalization factor when the geometry is ' +
+                        'generated. ' +
+                        'Default=1'
+                        )
     parser.add_argument('-v', '--viz',
-        action = 'store_true',
-        required = False,
-        dest = 'tagviz',
-        help = 'If set, surfaces generated in full or moab-only mode ' +\
-            'will be tagged with data for visualization purposes.'
-        )
-    parser.add_argument('-wl', '--writelevels',
-        action = 'store_true',
-        required = False,
-        dest = 'writelevels',
-        help = 'If set, values used for generating isosurfaces ' +\
-            'in full or visit-only mode will be written to a file named levels.txt ' +\
-            'in the database folder. ' +\
-            'File can then be read in with the --levelfile argument.'
-        )
+                        action='store_true',
+                        required=False,
+                        dest='tagviz',
+                        help='If set, surfaces generated will be tagged ' +
+                        'with data for visualization purposes.'
+                        )
     parser.add_argument('-g', '--geomfile',
-        action = 'store',
-        nargs = 1,
-        required = False,
-        default = None,
-        metavar = 'GEOM_FILENAME',
-        dest = 'geomfile',
-        type = str,
-        help = 'Filename and relative path to write generated isosurface geometry file. ' +\
-            'Must be either a .h5m or .vtk file name. Default name is geom-DATA.h5m ' +\
-            'where DATA is the name of data specified by -d if provided. ' +\
-            'If not provided, then default is geom.h5m' +\
-            'Default location is the database location (-db).'
-        )
-    parser.add_argument('-tv', '--tagval',
-        action = 'append',
-        nargs = 1,
-        required = False,
-        default = None,
-        metavar = 'TAG_VAL',
-        dest = 'tagvals',
-        type = float,
-        help = 'Use with --tagname. Value will be assigned to ' +\
-            'a MOAB tag on the geometry whose name corresponds to --tagname specified. ' +\
-            'Option can be used multiple times for multiple tags. ' +\
-            'The number of times this option is used must match the number of times --tagname is used.'
-        )
-    parser.add_argument('-tn', '--tagname',
-        action = 'append',
-        nargs = 1,
-        required = False,
-        default = None,
-        metavar = 'TAG_NAME',
-        dest = 'tagnames',
-        type = str,
-        help = 'Use with --tagval. Name will be used to create ' +\
-            'a MOAB tag on the geometry with this name whose value ' +\
-            'is the corresponding --tagval. ' +\
-            'Option can be used multiple times for multiple tags. ' +\
-            'The number of times this option is used must match the number of times --tagval is used.'
-        )
+                        action='store',
+                        nargs=1,
+                        required=False,
+                        default=None,
+                        metavar='GEOM_FILENAME',
+                        dest='geomfile',
+                        type=str,
+                        help='Filename and relative path to write generated ' +
+                        'isosurface geometry file. ' +
+                        'Must be either a .h5m or .vtk file name. ' +
+                        'Default name is isogeom.h5m in the database ' +
+                        'location (-db).'
+                        )
+
 
 def set_shared_options(parser, moab=False):
     """set options that are in both the moab and visit steps.
     """
     set_level_options(parser, moab)
     parser.add_argument('-db', '--database',
-        action = 'store',
-        nargs = 1,
-        required = False,
-        default = "/tmp",
-        metavar = 'DATABASE_PATH',
-        dest = 'db',
-        type = str,
-        help = 'Relative path to folder where isosurface meshfiles will be written from VisIT. ' +\
-            'Default is a folder named tmp/ in the current directory.'
-        )
+                        action='store',
+                        nargs=1,
+                        required=False,
+                        default="/tmp",
+                        metavar='DATABASE_PATH',
+                        dest='db',
+                        type=str,
+                        help='Relative path to folder where isosurface ' +
+                        'meshfiles from VisIt are located or to be saved. ' +
+                        'Default is a folder named tmp/ in the current ' +
+                        'directory.'
+                        )
 
 
 def parse_arguments():
     """parse user args
     """
 
-    parser = argparse.ArgumentParser(description="Generate isosurface geometry from a Cartesian mesh with VisIt and MOAB")
-    subparsers = parser.add_subparsers(title='Run Mode', help="Select mode for generating geometry.")
+    parser = argparse.ArgumentParser(description='Generate isosurface ' +
+                                     'geometry from a Cartesian mesh file ' +
+                                     'with VisIt and MOAB')
+    subparsers = parser.add_subparsers(title='Run Steps',
+                                       help="Select which steps to run for ' +
+                                       'generating the geometry.')
 
     # set full mode options
-    full_parser = subparsers.add_parser('full', help = 'Start-to-finish generation from a Cartesian mesh file to a DAGMC-compliant geometry.')
+    full_parser = subparsers.add_parser('full', help='Start-to-finish ' +
+                                        'generation from a Cartesian mesh ' +
+                                        'file to a DAGMC-compliant geometry.')
     set_visit_only_options(full_parser)
     set_shared_options(full_parser)
     set_moab_only_options(full_parser)
     full_parser.set_defaults(which='full')
 
     # set visit only mode options
-    visit_parser = subparsers.add_parser('visit', help = 'Only generate the isosurface mesh files using VisIt.')
+    visit_parser = subparsers.add_parser('visit', help='Only generate the ' +
+                                         'isosurface mesh files using VisIt.')
     set_visit_only_options(visit_parser)
     set_shared_options(visit_parser)
     visit_parser.set_defaults(which='visit')
 
     # set moab only mode options
-    moab_parser = subparsers.add_parser('moab', help = 'Only generate the geometry with MOAB starting from the VisIt mesh files.')
+    moab_parser = subparsers.add_parser('moab', help='Only generate the ' +
+                                        'DAGMC-compliant geometry with MOAB ' +
+                                        'starting from the VisIt mesh files.')
     set_shared_options(moab_parser, moab=True)
     set_moab_only_options(moab_parser)
     moab_parser.set_defaults(which='moab')

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -312,7 +312,7 @@ def main():
                           norm=args.norm[0],
                           merg_tol=args.merg_tol[0],
                           tags=tags,
-                          db=db)
+                          dbname=db)
 
 
 if __name__ == "__main__":

--- a/IsogeomGenerator/generate_isogeom.py
+++ b/IsogeomGenerator/generate_isogeom.py
@@ -4,8 +4,16 @@ import vol as v
 
 
 def set_level_options(parser, moab):
-    """Sets options for specifying level values. If moab mode, do not
-    give options for generating levels.
+    """Sets options for specifying level values.
+
+    Three options are available (two available for MOAB mode). Exactly one
+    option must be supplied. If in MOAB mode (moab=True), do not give options
+    for generating levels.
+
+    Input:
+    ------
+        parser: ArgumentParser object to attach options to
+        moab: bool, True if setting MOAB args
     """
     level_group = parser.add_mutually_exclusive_group(required=True)
     level_group.add_argument('-lf', '--levelfile',
@@ -81,7 +89,11 @@ def set_level_options(parser, moab):
 
 
 def set_visit_only_options(parser):
-    """set options specific to the Visit step.
+    """Set options specific to the VisIt step.
+
+    Input:
+    ------
+        parser: ArgumentParser object to attach options to
     """
     parser.add_argument('meshfile',
                         action='store',
@@ -102,7 +114,11 @@ def set_visit_only_options(parser):
 
 
 def set_moab_only_options(parser):
-    """Set options specific to the MOAB step
+    """Set options specific to the MOAB step.
+
+    Input:
+    ------
+        parser: ArgumentParser object to attach options to
     """
     parser.add_argument('-m', '--mergetol',
                         action='store',
@@ -176,7 +192,12 @@ def set_moab_only_options(parser):
 
 
 def set_shared_options(parser, moab=False):
-    """set options that are in both the moab and visit steps.
+    """Set options that are for both the MOAB and VisIt steps.
+
+    Input:
+    ------
+        parser: ArgumentParser object to attach options to
+        moab: bool, True if setting MOAB args (default=False)
     """
     set_level_options(parser, moab)
     parser.add_argument('-db', '--database',
@@ -195,9 +216,7 @@ def set_shared_options(parser, moab=False):
 
 
 def parse_arguments():
-    """parse user args
-    """
-
+    """Parse user args"""
     parser = argparse.ArgumentParser(description='Generate isosurface ' +
                                      'geometry from a Cartesian mesh file ' +
                                      'with VisIt and MOAB')
@@ -234,7 +253,13 @@ def parse_arguments():
 
 
 def check_level_gen(args):
-    """Check that correct args were supplied if generating level
+    """Check that correct args were supplied for generating levels.
+
+    If the min/max values or N are not supplied, then raise error.
+
+    Input:
+    ------
+        args: set of ArgumentParser args
     """
     if (args.extN is None) or (args.N is None):
         raise RuntimeError("Min/Max level values (-lx) and number of levels " +
@@ -246,7 +271,7 @@ def get_levels(args, g):
 
     Input:
     ------
-        args: argparse ArgumentParser
+        args: set of ArgumentParser args
         g: IsoVolume instance
     """
     # collect level information:
@@ -269,8 +294,10 @@ def get_levels(args, g):
 
 
 def process_tags(tags):
-    """Convert the provided tag information to a dictionary to pass to the
-    geometry creation stepself.
+    """Process the provided tag information to correct format.
+
+    Converts the list of information to a dictionary to be able to pass to the
+    geometry creation step.
 
     Input:
     -----

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -154,8 +154,8 @@ class IsoVolume(object):
                 values in VisIt. Default=False.
             norm: float (optional), default=1. All ww values will be
                 multiplied by the normalization factor.
-            merge_tol: float (option), default=1e-5 cm. Merge tolerance for mesh
-                based merge of coincident surfaces. Recommended to be
+            merge_tol: float (option), default=1e-5 cm. Merge tolerance for
+                mesh based merge of coincident surfaces. Recommended to be
                 1/10th the mesh voxel size.
         """
 
@@ -167,8 +167,8 @@ class IsoVolume(object):
         try:
             self.db
         except:
-            print("ERROR: Database not found. " +\
-                "Please run generate_volumes first.")
+            print("ERROR: Database not found. " +
+                  "Please run generate_volumes first.")
             sys.exit()
 
         # Step 1: Separate Isovolume Surfaces
@@ -198,17 +198,16 @@ class IsoVolume(object):
 
         # tag energy bounds on the root set
         el_tag = self.mb.tag_get_handle('E_LOW_BOUND', size=1,
-                        tag_type=types.MB_TYPE_DOUBLE,
-                        storage_type=types.MB_TAG_SPARSE,
-                        create_if_missing=True)
+                                        tag_type=types.MB_TYPE_DOUBLE,
+                                        storage_type=types.MB_TAG_SPARSE,
+                                        create_if_missing=True)
         eu_tag = self.mb.tag_get_handle('E_UP_BOUND', size=1,
-                        tag_type=types.MB_TYPE_DOUBLE,
-                        storage_type=types.MB_TAG_SPARSE,
-                        create_if_missing=True)
+                                        tag_type=types.MB_TYPE_DOUBLE,
+                                        storage_type=types.MB_TAG_SPARSE,
+                                        create_if_missing=True)
         rs = self.mb.get_root_set()
         self.mb.tag_set_data(el_tag, rs, e_lower)
         self.mb.tag_set_data(eu_tag, rs, e_upper)
-
 
     def write_geometry(self, sname="", sdir=""):
         """Writes out the geometry stored in memory.
@@ -224,8 +223,8 @@ class IsoVolume(object):
         try:
             self.mb
         except:
-            print("ERROR: No geometry in memory to write to file. " + \
-                "Please run create_geometry first.")
+            print("ERROR: No geometry in memory to write to file. " +
+                  "Please run create_geometry first.")
             sys.exit()
 
         # create default filename if unassigned.
@@ -233,18 +232,18 @@ class IsoVolume(object):
             try:
                 self.data
             except:
-                print("WARNING: Data name is unknown! " + \
-                    "File will be saved as geom-isovols.h5m.")
-                sname="geom-isovols.h5m"
+                print("WARNING: Data name is unknown! " +
+                      "File will be saved as geom-isovols.h5m.")
+                sname = "geom-isovols.h5m"
             else:
-                sname="geom-{}.h5m".format(self.data)
+                sname = "geom-{}.h5m".format(self.data)
 
         if sdir == "":
             try:
                 self.db
             except:
-                print("WARNING: Database location is unknown! " + \
-                    "File will be saved in tmp/ folder.")
+                print("WARNING: Database location is unknown! " +
+                      "File will be saved in tmp/ folder.")
                 sdir = os.getcwd() + "/tmp"
             else:
                 sdir = self.db
@@ -252,8 +251,8 @@ class IsoVolume(object):
         # check file extension of save name:
         ext = sname.split(".")[-1]
         if ext.lower() not in ['h5m', 'vtk']:
-            print("WARNING: File extension {} ".format(ext) +\
-                " not recognized. File will be saved as type .h5m.")
+            print("WARNING: File extension {} ".format(ext) +
+                  " not recognized. File will be saved as type .h5m.")
             self.sname = sname.split(".")[0] + ".h5m"
 
         # save the file
@@ -263,7 +262,6 @@ class IsoVolume(object):
         self.mb.write_file(save_location)
 
         print("Geometry file written to {}.".format(save_location))
-
 
     ################################################################
     ################# Extra functions for VisIT step ###############
@@ -286,7 +284,6 @@ class IsoVolume(object):
         v.SetPlotOptions(att)
         v.DrawPlots()
 
-
     def _update_levels(self, value):
         """Removes a value from the levels list and resets N.
 
@@ -297,7 +294,6 @@ class IsoVolume(object):
 
         self.levels.remove(value)
         self.N = len(self.levels)
-
 
     def _get_isovol(self, lbound, ubound, i):
         """Gets the volume selection for isovolume and export just the
@@ -350,7 +346,6 @@ class IsoVolume(object):
 
         return export_res, ubound
 
-
     def _generate_vols(self):
         """Generates the isosurface volumes between the contour levels.
         Data files are exported as STLs and saved in the folder dbname.
@@ -396,7 +391,6 @@ class IsoVolume(object):
 
         # delete plots
         v.DeleteAllPlots()
-
 
     ##############################################################
     ############## Functions for PyMOAB step #####################
@@ -471,26 +465,27 @@ class IsoVolume(object):
             # resassign vertices that remain
             all_verts = self.mb.get_entities_by_type(fs, types.MBVERTEX)
 
-
     def _separate_isovols(self):
         """For each isovolume in the database, separate any disjoint
         surfaces into unique single surfaces.
         """
 
         tol_set = False
-        facet_tol_tag = self.mb.tag_get_handle('FACETING_TOL', size=1,
-                        tag_type=types.MB_TYPE_DOUBLE,
-                        storage_type=types.MB_TAG_SPARSE,
-                        create_if_missing=True)
-        resabs_tag = self.mb.tag_get_handle('GEOMETRY_RESABS', size=1,
-                        tag_type=types.MB_TYPE_DOUBLE,
-                        storage_type=types.MB_TAG_SPARSE,
-                        create_if_missing=True)
+        facet_tol_tag = \
+            self.mb.tag_get_handle('FACETING_TOL', size=1,
+                                   tag_type=types.MB_TYPE_DOUBLE,
+                                   storage_type=types.MB_TAG_SPARSE,
+                                   create_if_missing=True)
+        resabs_tag = \
+            self.mb.tag_get_handle('GEOMETRY_RESABS', size=1,
+                                   tag_type=types.MB_TYPE_DOUBLE,
+                                   storage_type=types.MB_TAG_SPARSE,
+                                   create_if_missing=True)
 
         for f in sorted(os.listdir(self.db + "/vols/")):
             # get file name
             fpath = self.db + "/vols/" + f
-            i = int(f.strip(".stl")) # must be an integer
+            i = int(f.strip(".stl"))  # must be an integer
 
             # load file and create EH for file-set
             fs = self.mb.create_meshset()
@@ -519,7 +514,6 @@ class IsoVolume(object):
             else:
                 self.isovol_meshsets[iv_info]['bounds'] =\
                     (self.levels[i-1], self.levels[i])
-
 
     def _list_coords(self, eh, invert=False):
         """Gets list of all coords as a list of tuples for an entity
@@ -555,7 +549,6 @@ class IsoVolume(object):
             coords[key] = value
 
         return coords
-
 
     def _get_matches(self, vertsA, vertsB):
         """Collects the set of entity handles and coordinates in set of
@@ -630,9 +623,8 @@ class IsoVolume(object):
 
                     match_dict[ehB] = ehA
 
-
-        return sA_match_eh, sA_match_coords, sB_match_eh, sB_match_coords, match_dict
-
+        return sA_match_eh, sA_match_coords, sB_match_eh, sB_match_coords, \
+            match_dict
 
     def _get_surf_triangles(self, verts_good):
         """This function will take a set of vertice entity handles and
@@ -663,7 +655,6 @@ class IsoVolume(object):
         else:
             # empty set so all tris are good
             return tris_all
-
 
     def _compare_surfs(self, v1, v2):
         """finds coincident surfaces between two isovolumes.
@@ -698,8 +689,8 @@ class IsoVolume(object):
 
                 # compare vertices and gather sets for s1 and s2
                 # that are coincident
-                s1_match_eh, s1_match_coords, s2_match_eh, s2_match_coords, match_dict =\
-                    self._get_matches(verts1, verts2_inv)
+                s1_match_eh, s1_match_coords, s2_match_eh, s2_match_coords, \
+                    match_dict = self._get_matches(verts1, verts2_inv)
 
                 if s1_match_eh != []:
                     # matches were found, so continue
@@ -732,16 +723,20 @@ class IsoVolume(object):
                         self.surf_curve[s2].append(curve)
                         self.surf_curve[surf].append(curve)
 
-                        # remove merged verts and tris from each already existing surf
+                        # remove merged verts and tris from each already
+                        # existing surf
                         for vert_delete in s2_match_eh:
 
-                            # get all triangles connected to the vert to be deleted
-                            tris_adjust = self.mb.get_adjacencies(vert_delete, 2, op_type=1)
+                            # get all triangles connected to the vert to be
+                            # deleted
+                            tris_adjust = self.mb.get_adjacencies(vert_delete,
+                                                                  2, op_type=1)
 
                             # get the vert that will replace the deleted vert
                             replacement = match_dict[vert_delete]
 
-                            # for every tri to be deleted, replace vert by setting connectivity
+                            # for every tri to be deleted, replace vert by
+                            # setting connectivity
                             for tri in tris_adjust:
                                 tri_verts = self.mb.get_connectivity(tri)
                                 new_verts = [0, 0, 0]
@@ -770,12 +765,12 @@ class IsoVolume(object):
                     fwd = v1[1]
                     bwd = v2[1]
                     self.mb.tag_set_data(self.sense_tag, surf,
-                                            [fwd, bwd])
+                                         [fwd, bwd])
 
                     # tag the new surface with the shared value
                     shared = \
-                        list(set(self.isovol_meshsets[v1]['bounds']) \
-                        & set(self.isovol_meshsets[v2]['bounds']))
+                        list(set(self.isovol_meshsets[v1]['bounds'])
+                             & set(self.isovol_meshsets[v2]['bounds']))
                     if not(bool(shared)):
                         print('no matching value!', v1, v2)
                         val = 0.0
@@ -789,14 +784,14 @@ class IsoVolume(object):
 
                     # check if original surfaces are empty (no vertices)
                     # if so delete empty meshset and remove from list
-                    s2_remaining = self.mb.get_entities_by_type(s2,
-                                                        types.MBVERTEX)
+                    s2_remaining = \
+                        self.mb.get_entities_by_type(s2, types.MBVERTEX)
                     if len(s2_remaining) == 0:
                         # delete surface from list and mb instance
                         self.isovol_meshsets[v2]['surfs_EH'].remove(s2)
 
-                    s1_remaining = self.mb.get_entities_by_type(s1,
-                                                        types.MBVERTEX)
+                    s1_remaining = \
+                        self.mb.get_entities_by_type(s1, types.MBVERTEX)
                     if len(s1_remaining) == 0:
                         # delete from list and mb instance and move to
                         # next surf
@@ -807,7 +802,6 @@ class IsoVolume(object):
         self.isovol_meshsets[v1]['surfs_EH'].extend(match_surfs)
         self.isovol_meshsets[v2]['surfs_EH'].extend(match_surfs)
 
-
     def _imprint_merge(self):
         """Uses PyMOAB to check if surfaces are coincident. Creates a
         single surface where surfaces are coincident values are tagged
@@ -815,14 +809,16 @@ class IsoVolume(object):
         """
 
         # set up surface tag information (value and sense)
-        self.val_tag = self.mb.tag_get_handle(self.data, size=1,
-                        tag_type=types.MB_TYPE_DOUBLE,
-                        storage_type=types.MB_TAG_SPARSE,
-                        create_if_missing=True)
-        self.sense_tag = self.mb.tag_get_handle('GEOM_SENSE_2', size=2,
-                        tag_type=types.MB_TYPE_HANDLE,
-                        storage_type=types.MB_TAG_SPARSE,
-                        create_if_missing=True)
+        self.val_tag = \
+            self.mb.tag_get_handle(self.data, size=1,
+                                   tag_type=types.MB_TYPE_DOUBLE,
+                                   storage_type=types.MB_TAG_SPARSE,
+                                   create_if_missing=True)
+        self.sense_tag = \
+            self.mb.tag_get_handle('GEOM_SENSE_2', size=2,
+                                   tag_type=types.MB_TYPE_HANDLE,
+                                   storage_type=types.MB_TAG_SPARSE,
+                                   create_if_missing=True)
 
         # create dictionary of curves to match to surfaces:
         # key = surf eh, value = list of child curve eh
@@ -848,8 +844,9 @@ class IsoVolume(object):
                 except:
                     val = 0.0
                     self.mb.tag_set_data(self.val_tag, surf, val)
-                    verts = self.mb.get_entities_by_type(surf,
-                            types.MBVERTEX)
+                    verts = \
+                        self.mb.get_entities_by_type(surf,
+                                                     types.MBVERTEX)
                     tris = self._get_surf_triangles(verts)
                     self.mb.add_entities(surf, tris)
 
@@ -860,8 +857,7 @@ class IsoVolume(object):
                     fwd = isovol[1]
                     bwd = np.uint64(0)
                     self.mb.tag_set_data(self.sense_tag,
-                                        surf, [fwd, bwd])
-
+                                         surf, [fwd, bwd])
 
     def _make_family(self):
         """Makes the correct parent-child relationships with volumes
@@ -869,18 +865,21 @@ class IsoVolume(object):
         and volumes.
         """
         # create geometry dimension, category, and global id tags
-        geom_dim = self.mb.tag_get_handle('GEOM_DIMENSION', size=1,
-                        tag_type=types.MB_TYPE_INTEGER,
-                        storage_type=types.MB_TAG_SPARSE,
-                        create_if_missing=True)
-        category = self.mb.tag_get_handle('CATEGORY', size=32,
-                        tag_type=types.MB_TYPE_OPAQUE,
-                        storage_type=types.MB_TAG_SPARSE,
-                        create_if_missing=True)
-        global_id = self.mb.tag_get_handle('GLOBAL_ID', size=1,
-                        tag_type=types.MB_TYPE_INTEGER,
-                        storage_type=types.MB_TAG_SPARSE,
-                        create_if_missing=True)
+        geom_dim = \
+            self.mb.tag_get_handle('GEOM_DIMENSION', size=1,
+                                   tag_type=types.MB_TYPE_INTEGER,
+                                   storage_type=types.MB_TAG_SPARSE,
+                                   create_if_missing=True)
+        category = \
+            self.mb.tag_get_handle('CATEGORY', size=32,
+                                   tag_type=types.MB_TYPE_OPAQUE,
+                                   storage_type=types.MB_TAG_SPARSE,
+                                   create_if_missing=True)
+        global_id = \
+            self.mb.tag_get_handle('GLOBAL_ID', size=1,
+                                   tag_type=types.MB_TYPE_INTEGER,
+                                   storage_type=types.MB_TAG_SPARSE,
+                                   create_if_missing=True)
 
         vol_id = 0
         surf_id = 0
@@ -894,7 +893,6 @@ class IsoVolume(object):
             self.mb.tag_set_data(category, vol_eh, 'Volume')
             vol_id += 1
             self.mb.tag_set_data(global_id, vol_eh, vol_id)
-
 
             for surf_eh in self.isovol_meshsets[v]['surfs_EH']:
                 # create relationship
@@ -912,12 +910,11 @@ class IsoVolume(object):
                 # create relationship
                 self.mb.add_parent_child(s, c)
 
-                 # tag curves
+                # tag curves
                 self.mb.tag_set_data(geom_dim, c, 1)
                 self.mb.tag_set_data(category, c, 'Curve')
                 curve_id += 1
                 self.mb.tag_set_data(global_id, c, curve_id)
-
 
     def _tag_groups(self):
         """Tags the surfaces with metadata as a group with value
@@ -926,16 +923,18 @@ class IsoVolume(object):
         """
 
         # category tag
-        category = self.mb.tag_get_handle('CATEGORY', size=32,
-                        tag_type=types.MB_TYPE_OPAQUE,
-                        storage_type=types.MB_TAG_SPARSE,
-                        create_if_missing=True)
+        category = \
+            self.mb.tag_get_handle('CATEGORY', size=32,
+                                   tag_type=types.MB_TYPE_OPAQUE,
+                                   storage_type=types.MB_TAG_SPARSE,
+                                   create_if_missing=True)
 
         # tag for group metadata
-        tag_name = self.mb.tag_get_handle('NAME', size=32,
-                                tag_type=types.MB_TYPE_OPAQUE,
-                                storage_type=types.MB_TAG_SPARSE,
-                                create_if_missing=True)
+        tag_name = \
+            self.mb.tag_get_handle('NAME', size=32,
+                                   tag_type=types.MB_TYPE_OPAQUE,
+                                   storage_type=types.MB_TAG_SPARSE,
+                                   create_if_missing=True)
 
         # strip underscores from base data name
         data = self.data.replace('_', '')
@@ -965,7 +964,6 @@ class IsoVolume(object):
                 # add to group with that same data
                 self.mb.add_entities(data_groups[val], [surf])
 
-
     def _tag_for_viz(self):
         """Tags all triangles on all surfaces with the data value for
         that surface. This is for vizualization purposes.
@@ -977,7 +975,7 @@ class IsoVolume(object):
 
                 # get the triangles
                 tris = self.mb.get_entities_by_type(surf,
-                            types.MBTRI)
+                                                    types.MBTRI)
 
                 # create data array
                 num = len(tris)

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -174,7 +174,7 @@ class IsoVolume(object):
 
         # Step 2: Merge Coincident Surfaces
         print("Merging surfaces...")
-        self._imprint_merge()
+        self.__imprint_merge()
         print("...Merging complete!")
 
         # Step 3: Assign Parent-Child Relationship
@@ -299,7 +299,7 @@ class IsoVolume(object):
         # get the minimum isovolume level
         lbound = 0.0
         ubound = self.levels[0]
-        self._get_isovol(lbound, ubound, 0)
+        self.__get_isovol(lbound, ubound, 0)
 
         # iterate over all isovolume levels
         for l in self.levels[1:]:
@@ -314,12 +314,12 @@ class IsoVolume(object):
 
                 # get volume
                 # res = 0 if no level found (should update to next level)
-                res = self._get_isovol(lbound, ubound, i)
+                res = self.__get_isovol(lbound, ubound, i)
 
         # get maximum isovolume level
         lbound = self.levels[-1]
         ubound = 1.e200
-        self._get_isovol(lbound, ubound, i+1)
+        self.__get_isovol(lbound, ubound, i+1)
 
         # delete plots
         v.DeleteAllPlots()
@@ -716,7 +716,7 @@ class IsoVolume(object):
         self.isovol_meshsets[v1]['surfs_EH'].extend(match_surfs)
         self.isovol_meshsets[v2]['surfs_EH'].extend(match_surfs)
 
-    def _imprint_merge(self):
+    def __imprint_merge(self):
         """Uses PyMOAB to check if surfaces are coincident. Creates a
         single surface where surfaces are coincident values are tagged
         on each surface. Surface senses are also determined and tagged.

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -26,7 +26,7 @@ class IsoVolume(object):
         pass
 
     def assign_levels(self, levels):
-        """User defines the contour levels to be used in the isovolumes.
+        """User defines the contour levels to be used as the isosurfaces.
 
         Input:
         ------

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -81,7 +81,6 @@ class IsoVolume(object):
             self.levels = list(np.logspace(start, stop, num=N,
                                endpoint=True, base=base))
         elif mode == 'ratio':
-            # ratio being used
             # set minN as the minimum value and get all other values until maxN
             tmpmax = 0.
             self.levels = [minN]

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -135,9 +135,9 @@ class IsoVolume(object):
         print("...Isovolumes files generated!")
         v.CloseComputeEngine()
 
-    def create_geometry(self, e_lower, e_upper, tag_groups=False,
+    def create_geometry(self, tag_groups=False,
                         tag_for_viz=False, norm=1.0,
-                        merge_tol=1e-5, db=None):
+                        merge_tol=1e-5, db=None, tags=None):
         """Over-arching function to do all steps to create a single
         isovolume geometry for DAGMC.
 
@@ -189,18 +189,9 @@ class IsoVolume(object):
             self._tag_for_viz()
             print('... tags complete')
 
-        # tag energy bounds on the root set
-        el_tag = self.mb.tag_get_handle('E_LOW_BOUND', size=1,
-                                        tag_type=types.MB_TYPE_DOUBLE,
-                                        storage_type=types.MB_TAG_SPARSE,
-                                        create_if_missing=True)
-        eu_tag = self.mb.tag_get_handle('E_UP_BOUND', size=1,
-                                        tag_type=types.MB_TYPE_DOUBLE,
-                                        storage_type=types.MB_TAG_SPARSE,
-                                        create_if_missing=True)
-        rs = self.mb.get_root_set()
-        self.mb.tag_set_data(el_tag, rs, e_lower)
-        self.mb.tag_set_data(eu_tag, rs, e_upper)
+        if tags is not None:
+            self._set_tags(tags)
+
 
     def write_geometry(self, sname="", sdir=""):
         """Writes out the geometry stored in memory.
@@ -909,3 +900,18 @@ class IsoVolume(object):
 
                 # tag the data
                 self.mb.tag_set_data(self.val_tag, tris, data)
+
+    def _set_tags(self, tags):
+        """Set provided tag values on the root set.
+
+        Input:
+        ------
+            tags: dict, key=TAGNAME, value=TAGVALUE
+        """
+        rs = self.mb.get_root_set()
+        for tagname, tagval in tags.items():
+            tag = self.mb.tag_get_handle(tagname, size=1,
+                                         tag_type=types.MB_TYPE_DOUBLE,
+                                         storage_type=types.MB_TAG_SPARSE,
+                                         create_if_missing=True)
+            self.mb.tag_set_data(tag, rs, tagval)

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -25,7 +25,6 @@ class IsoVolume(object):
     def __init__(self):
         pass
 
-
     def assign_levels(self, levels):
         """User defines the contour levels to be used in the isovolumes.
 
@@ -40,7 +39,6 @@ class IsoVolume(object):
         self.minN = min(self.levels)
         self.maxN = max(self.levels)
         self.N = len(self.levels)
-
 
     def generate_levels(self, N, minN, maxN, log=True, ratio=False):
         """Auto-generate evenly-spaced level values to use given a
@@ -78,10 +76,10 @@ class IsoVolume(object):
                 start = m.log(self.minN, base)
                 stop = m.log(self.maxN, base)
                 self.levels = list(np.logspace(start, stop, num=self.N,
-                                        endpoint=True, base=base))
+                                               endpoint=True, base=base))
             else:
                 self.levels = list(np.linspace(self.minN, self.maxN,
-                                        num=self.N, endpoint=True))
+                                               num=self.N, endpoint=True))
 
         else:
             # ratio being used
@@ -100,9 +98,8 @@ class IsoVolume(object):
 
             self.N = len(self.levels)
 
-
     def generate_volumes(self, filename, data,
-                            dbname=os.getcwd()+"/tmp"):
+                         dbname=os.getcwd()+"/tmp"):
         """Creates an STL file for each isovolume. N+1 files are
         generated and stored in the dbname folder.
 
@@ -124,8 +121,8 @@ class IsoVolume(object):
         try:
             self.levels
         except:
-            print("ERROR: No contour levels have been set. " +\
-                "Please use assign_levels or generate_levels to set.")
+            print("ERROR: No contour levels have been set. " +
+                  "Please use assign_levels or generate_levels to set.")
             sys.exit()
 
         # Generate isovolumes using VisIT
@@ -139,8 +136,8 @@ class IsoVolume(object):
         print("...Isovolumes files generated!")
         v.CloseComputeEngine()
 
-
-    def create_geometry(self, e_lower, e_upper, tag_groups=False, tag_for_viz=False, norm=1.0,
+    def create_geometry(self, e_lower, e_upper, tag_groups=False,
+                        tag_for_viz=False, norm=1.0,
                         merge_tol=1e-5, facet_tol=1e-3):
         """Over-arching function to do all steps to create a single
         isovolume geometry for DAGMC.

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -263,8 +263,8 @@ class IsoVolume(object):
         if export_res == 0:
             # export not successful because there was no data
             # get new upper bound
-            warn_message = "Warning: no data to export between " +
-            "{} and {}.\n".format(lbound, ubound) +
+            warn_message = "Warning: no data to export between " +\
+            "{} and {}.\n".format(lbound, ubound) +\
             "Increasing upper bound to next selected level."
             print(warn_message)
             if ubound in self.levels:

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -264,8 +264,8 @@ class IsoVolume(object):
             # export not successful because there was no data
             # get new upper bound
             warn_message = "Warning: no data to export between " +\
-            "{} and {}.\n".format(lbound, ubound) +\
-            "Increasing upper bound to next selected level."
+                "{} and {}.\n".format(lbound, ubound) +\
+                "Increasing upper bound to next selected level."
             print(warn_message)
             if ubound in self.levels:
                 self.__update_levels(ubound)

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -40,8 +40,21 @@ class IsoVolume(object):
         self.maxN = max(self.levels)
         self.N = len(self.levels)
 
-    def read_levels(self, filename):
-        print(filename)
+    def read_levels(self, levelfile):
+        """Read level values from a file. One value per line only.
+
+        Input:
+        ------
+            levelfile: str, relative path to file with level information.
+        """
+        levels = []
+        f = open(levelfile, 'r')
+        lines = f.readlines()
+        for line in lines:
+            levels.append(float(line))
+
+        self.levels = sorted(levels)
+        print(levels)
 
     def generate_levels(self, N, minN, maxN, log=True, ratio=False):
         """Auto-generate evenly-spaced level values to use given a

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -60,17 +60,16 @@ class IsoVolume(object):
         Input:
         ------
             N: int or float, number of levels (int) to generate
-                (ratio=False); or the ratio (float) to use to separate
-                levels (ratio=True).
+                (lin or log mode); or the ratio (float) to use to separate
+                levels (ratio mode).
             minN: float, minimum level value
             maxN: float, maximum level value
-            log: bool (optional), True to generate evenly spaced levels
-                on a log scale (default), False to use linear scale.
-            ratio: bool (optional), True to generate levels that are
-                spaced by some constant ratio N. If True, log input is
-                ignored. If True, minN will be used as minimum level
-                value, maximum level value is less than or equal to
-                maxN.
+            mode: str, options are 'lin' (default), 'log', or 'ratio'.
+                lin: N linearly spaced values between minN and maxN
+                log: N logarithmically spaced values between minN and maxN
+                ratio: levels that are spaced by a constant ratio N.
+                    minN will be used as minimum level value and the maximum
+                    level value is less than or equal to maxN.
         """
         if mode == 'lin':
             self.levels = list(np.linspace(minN, maxN,

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -263,8 +263,9 @@ class IsoVolume(object):
         if export_res == 0:
             # export not successful because there was no data
             # get new upper bound
-            warn_message = "Warning: no data to export between {} and {}.\n".format(lbound, ubound) \
-                + "Increasing upper bound to next selected level."
+            warn_message = "Warning: no data to export between " +
+            "{} and {}.\n".format(lbound, ubound) +
+            "Increasing upper bound to next selected level."
             print(warn_message)
             if ubound in self.levels:
                 self._update_levels(ubound)

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -54,7 +54,9 @@ class IsoVolume(object):
             levels.append(float(line))
 
         self.levels = sorted(levels)
-        print(levels)
+        self.minN = min(self.levels)
+        self.maxN = max(self.levels)
+        self.N = len(self.levels)
 
     def generate_levels(self, N, minN, maxN, log=True, ratio=False):
         """Auto-generate evenly-spaced level values to use given a

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -226,7 +226,7 @@ class IsoVolume(object):
 
         self.levels.remove(value)
 
-    def _get_isovol(self, lbound, ubound, i):
+    def __get_isovol(self, lbound, ubound, i):
         """Gets the volume selection for isovolume and export just the
         outer surface of the volume as STL.
 

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -143,7 +143,7 @@ class IsoVolume(object):
             tag_for_viz: bool (optional), True to tag each triangle on
                 every surface with the data value. Needed to visualize
                 values in VisIt. Default=False.
-            norm: float (optional), default=1. All ww values will be
+            norm: float (optional), default=1. All data values will be
                 multiplied by the normalization factor.
             merge_tol: float (option), default=1e-5 cm. Merge tolerance for
                 mesh based merge of coincident surfaces. Recommended to be

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -156,7 +156,7 @@ class IsoVolume(object):
 
     def create_geometry(self, e_lower, e_upper, tag_groups=False,
                         tag_for_viz=False, norm=1.0,
-                        merge_tol=1e-5, facet_tol=1e-3):
+                        merge_tol=1e-5, facet_tol=1e-3, db=None):
         """Over-arching function to do all steps to create a single
         isovolume geometry for DAGMC.
 

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -84,7 +84,7 @@ class IsoVolume(object):
             # set minN as the minimum value and get all other values until maxN
             tmpmax = 0.
             self.levels = [minN]
-            while tmpmsx < maxN:
+            while tmpmax < maxN:
                 next_val = self.levels[-1]*float(N)
                 if next_val <= maxN:
                     self.levels.append(next_val)

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -275,9 +275,9 @@ class IsoVolume(object):
 
         # min/max for the pseudocolor plot
         att.minFlag = True
-        att.min = self.minN
+        att.min = min(self.levels)
         att.maxFlag = True
-        att.max = self.maxN
+        att.max = max(self.levels)
 
         # plot
         v.SetPlotOptions(att)
@@ -292,7 +292,6 @@ class IsoVolume(object):
         """
 
         self.levels.remove(value)
-        self.N = len(self.levels)
 
     def _get_isovol(self, lbound, ubound, i):
         """Gets the volume selection for isovolume and export just the
@@ -507,7 +506,7 @@ class IsoVolume(object):
             if i == 0:
                 self.isovol_meshsets[iv_info]['bounds'] =\
                     (None, self.levels[i])
-            elif i == self.N:
+            elif i == len(self.levels):
                 self.isovol_meshsets[iv_info]['bounds'] =\
                     (self.levels[i-1], None)
             else:
@@ -827,7 +826,7 @@ class IsoVolume(object):
         all_vols = sorted(self.isovol_meshsets.keys())
         for i, isovol in enumerate(all_vols):
 
-            if i != self.N:
+            if i != len(self.levels):
                 # do not need to check the last isovolume because it
                 # will be checked against its neighbor already
                 self._compare_surfs(isovol, all_vols[i+1])

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -53,9 +53,8 @@ class IsoVolume(object):
         self.levels = sorted(levels)
 
     def generate_levels(self, N, minN, maxN, mode='lin'):
-        """Auto-generate evenly-spaced level values to use given a
-        user-defined maximum, minimum, and number of levels or set
-        constant ratio for spacing.
+        """Auto-generate evenly-spaced level values between the min and max
+        value.
 
         Input:
         ------

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -136,7 +136,7 @@ class IsoVolume(object):
                         dbname=os.getcwd()+"/tmp", tags=None,
                         sname=None, sdir=None):
         """Over-arching function to do all steps to create a single
-        isovolume geometry for DAGMC using pyMOAB.
+        isosurface geometry for DAGMC using pyMOAB.
 
         Input:
         ------

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -133,19 +133,13 @@ class IsoVolume(object):
         print("...Isovolumes files generated!")
         v.CloseComputeEngine()
 
-    def create_geometry(self, tag_groups=False,
-                        tag_for_viz=False, norm=1.0,
-                        merge_tol=1e-5, db=None, tags=None):
+    def create_geometry(self, tag_for_viz=False, norm=1.0, merge_tol=1e-5,
+                        dbname=os.getcwd()+"/tmp", tags=None):
         """Over-arching function to do all steps to create a single
-        isovolume geometry for DAGMC.
+        isovolume geometry for DAGMC using pyMOAB.
 
         Input:
         ------
-            e_lower: double, energy group lower bound
-            e_upper: double, energy group upper bound
-            tag_groups: bool (optional), True to tag surfaces in groups
-                with NAMES '{data}_{value}' where data is the data name
-                and value is the value for that surface. Default=False.
             tag_for_viz: bool (optional), True to tag each triangle on
                 every surface with the data value. Needed to visualize
                 values in VisIt. Default=False.
@@ -154,18 +148,18 @@ class IsoVolume(object):
             merge_tol: float (option), default=1e-5 cm. Merge tolerance for
                 mesh based merge of coincident surfaces. Recommended to be
                 1/10th the mesh voxel size.
+            dbname: (optional), string, name of folder to store created
+                surface files. Must be absolute path.
+                default: a folder called 'tmp' in the current directory
+            tags: (optional), dict, set of names and values to tag on the
+                geometry root set. Dictionary should be structured with each
+                key as a tag name (str) and with a single value (float) for the
+                tag. Example: {'NAME1':1.0, 'NAME2': 2.0}
         """
 
         self.norm = norm
         self.merge_tol = merge_tol
-
-        # check that database is identified
-        try:
-            self.db
-        except:
-            print("ERROR: Database not found. " +
-                  "Please run generate_volumes first.")
-            sys.exit()
+        self.db = dbname
 
         # Step 1: Separate Isovolume Surfaces
         self.mb = core.Core()

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -40,6 +40,9 @@ class IsoVolume(object):
         self.maxN = max(self.levels)
         self.N = len(self.levels)
 
+    def read_levels(self, filename):
+        print(filename)
+
     def generate_levels(self, N, minN, maxN, log=True, ratio=False):
         """Auto-generate evenly-spaced level values to use given a
         user-defined maximum, minimum, and number of levels or set

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -184,11 +184,6 @@ class IsoVolume(object):
         # Step 3: Assign Parent-Child Relationship
         self._make_family()
 
-        if tag_groups:
-            print('Tagging data groups...')
-            self._tag_groups()
-            print('... tags complete')
-
         if tag_for_viz:
             print('Tagging triangles with data...')
             self._tag_for_viz()

--- a/IsogeomGenerator/vol.py
+++ b/IsogeomGenerator/vol.py
@@ -129,7 +129,7 @@ class IsoVolume(object):
             print("VisIt already launched.")
         v.OpenDatabase(filename)
         print("Generating isovolumes...")
-        self._generate_vols()
+        self.__generate_vols()
         print("...Isovolumes files generated!")
         v.CloseComputeEngine()
 
@@ -169,7 +169,7 @@ class IsoVolume(object):
         self.mb = core.Core()
         self.isovol_meshsets = {}
         print("Separating isovolumes...")
-        self._separate_isovols()
+        self.__separate_isovols()
         print("...Separation complete!")
 
         # Step 2: Merge Coincident Surfaces
@@ -178,28 +178,28 @@ class IsoVolume(object):
         print("...Merging complete!")
 
         # Step 3: Assign Parent-Child Relationship
-        self._make_family()
+        self.__make_family()
 
         if tag_for_viz:
             print('Tagging triangles with data...')
-            self._tag_for_viz()
+            self.__tag_for_viz()
             print('... tags complete')
 
         if tags is not None:
-            self._set_tags(tags)
+            self.__set_tags(tags)
 
         if sdir is None:
             sdir = self.dbname
         if sname is None:
             sname = 'isogeom.h5m'
 
-        _write_geometry(sname, sdir)
+        self.__write_geometry(sname, sdir)
 
     ################################################################
     ################# Extra functions for VisIT step ###############
     ################################################################
 
-    def _plot_pseudocolor(self):
+    def __plot_pseudocolor(self):
         """Plots the data on a pseudocolor plot to use."""
 
         # add the pseudocolor plot to contour
@@ -216,7 +216,7 @@ class IsoVolume(object):
         v.SetPlotOptions(att)
         v.DrawPlots()
 
-    def _update_levels(self, value):
+    def __update_levels(self, value):
         """Removes a value from the levels list and resets N.
 
         Input:
@@ -268,17 +268,17 @@ class IsoVolume(object):
             "Increasing upper bound to next selected level."
             print(warn_message)
             if ubound in self.levels:
-                self._update_levels(ubound)
+                self.__update_levels(ubound)
             else:
                 # it is the arbitrary upper level set and is not needed
-                self._update_levels(self.levels[-1])
+                self.__update_levels(self.levels[-1])
 
         # delete the operators
         v.RemoveAllOperators()
 
         return export_res, ubound
 
-    def _generate_vols(self):
+    def __generate_vols(self):
         """Generates the isosurface volumes between the contour levels.
         Data files are exported as STLs and saved in the folder dbname.
         Files will be named based on their index corresponding to their
@@ -294,7 +294,7 @@ class IsoVolume(object):
         os.mkdir(self.db + "/vols/")
 
         # plot the pseudocolor data inorder to get volumes
-        self._plot_pseudocolor()
+        self.__plot_pseudocolor()
 
         # get the minimum isovolume level
         lbound = 0.0
@@ -328,7 +328,7 @@ class IsoVolume(object):
     ############## Functions for PyMOAB step #####################
     ##############################################################
 
-    def _separate(self, iv_info):
+    def __separate(self, iv_info):
         """Separates a given surface into separate surfaces. All
         resulting surfaces are disjoint surfaces that made up the
         original surface.
@@ -383,7 +383,7 @@ class IsoVolume(object):
 
             # get the connected set of triangles that make the single
             # surface and store into a unique meshset
-            tris = self._get_surf_triangles(verts)
+            tris = self.__get_surf_triangles(verts)
             surf = self.mb.create_meshset()
             self.mb.add_entities(surf, tris)
             self.mb.add_entities(surf, verts)
@@ -397,7 +397,7 @@ class IsoVolume(object):
             # resassign vertices that remain
             all_verts = self.mb.get_entities_by_type(fs, types.MBVERTEX)
 
-    def _separate_isovols(self):
+    def __separate_isovols(self):
         """For each isovolume in the database, separate any disjoint
         surfaces into unique single surfaces.
         """
@@ -416,7 +416,7 @@ class IsoVolume(object):
             self.isovol_meshsets[iv_info] = {}
 
             # separate
-            self._separate(iv_info)
+            self.__separate(iv_info)
 
             # add value min/max info (min, max)
             if i == 0:
@@ -429,7 +429,7 @@ class IsoVolume(object):
                 self.isovol_meshsets[iv_info]['bounds'] =\
                     (self.levels[i-1], self.levels[i])
 
-    def _list_coords(self, eh, invert=False):
+    def __list_coords(self, eh, invert=False):
         """Gets list of all coords as a list of tuples for an entity
         handle eh.
 
@@ -464,7 +464,7 @@ class IsoVolume(object):
 
         return coords
 
-    def _get_matches(self, vertsA, vertsB):
+    def __get_matches(self, vertsA, vertsB):
         """Collects the set of entity handles and coordinates in set of
         vertsA and vertsB that match within the specified absolute
         tolerance (self.merge_tol).
@@ -540,7 +540,7 @@ class IsoVolume(object):
         return sA_match_eh, sA_match_coords, sB_match_eh, sB_match_coords, \
             match_dict
 
-    def _get_surf_triangles(self, verts_good):
+    def __get_surf_triangles(self, verts_good):
         """This function will take a set of vertice entity handles and
         return the set of triangles for which all vertices of all
         triangles are in the set of vertices.
@@ -570,7 +570,7 @@ class IsoVolume(object):
             # empty set so all tris are good
             return tris_all
 
-    def _compare_surfs(self, v1, v2):
+    def __compare_surfs(self, v1, v2):
         """finds coincident surfaces between two isovolumes.
 
         Input:
@@ -588,7 +588,7 @@ class IsoVolume(object):
         # compare all surfaces in v1 (s1) to all surfaces in v2 (s2)
         for s1 in self.isovol_meshsets[v1]['surfs_EH']:
             # get list of all coordinates in s1
-            verts1 = self._list_coords(s1)
+            verts1 = self.__list_coords(s1)
 
             # initialize list of curves
             if s1 not in self.surf_curve.keys():
@@ -599,21 +599,21 @@ class IsoVolume(object):
                     self.surf_curve[s2] = []
 
                 # get list of all coordinates in s2 (inverted)
-                verts2_inv = self._list_coords(s2, invert=True)
+                verts2_inv = self.__list_coords(s2, invert=True)
 
                 # compare vertices and gather sets for s1 and s2
                 # that are coincident
                 s1_match_eh, s1_match_coords, s2_match_eh, s2_match_coords, \
-                    match_dict = self._get_matches(verts1, verts2_inv)
+                    match_dict = self.__get_matches(verts1, verts2_inv)
 
                 if s1_match_eh != []:
                     # matches were found, so continue
 
                     # get only tris1 that have all match vertices
-                    tris1 = self._get_surf_triangles(s1_match_eh)
+                    tris1 = self.__get_surf_triangles(s1_match_eh)
 
                     # get s2 tris to delete (no new surface needed)
-                    tris2 = self._get_surf_triangles(s2_match_eh)
+                    tris2 = self.__get_surf_triangles(s2_match_eh)
 
                     # create new coincident surface
                     surf = self.mb.create_meshset()
@@ -745,7 +745,7 @@ class IsoVolume(object):
             if i != len(self.levels):
                 # do not need to check the last isovolume because it
                 # will be checked against its neighbor already
-                self._compare_surfs(isovol, all_vols[i+1])
+                self.__compare_surfs(isovol, all_vols[i+1])
 
         # if a surface doesn't have a value tagged after merging
         # give it a value of 0 and tag forward sense
@@ -761,7 +761,7 @@ class IsoVolume(object):
                     verts = \
                         self.mb.get_entities_by_type(surf,
                                                      types.MBVERTEX)
-                    tris = self._get_surf_triangles(verts)
+                    tris = self.__get_surf_triangles(verts)
                     self.mb.add_entities(surf, tris)
 
                 # tag fwd sense
@@ -773,7 +773,7 @@ class IsoVolume(object):
                     self.mb.tag_set_data(self.sense_tag,
                                          surf, [fwd, bwd])
 
-    def _make_family(self):
+    def __make_family(self):
         """Makes the correct parent-child relationships with volumes
         and surfaces. Tags geometry type, category, and ID on surfaces
         and volumes.
@@ -830,7 +830,7 @@ class IsoVolume(object):
                 curve_id += 1
                 self.mb.tag_set_data(global_id, c, curve_id)
 
-    def _tag_for_viz(self):
+    def __tag_for_viz(self):
         """Tags all triangles on all surfaces with the data value for
         that surface. This is for vizualization purposes.
         """
@@ -850,7 +850,7 @@ class IsoVolume(object):
                 # tag the data
                 self.mb.tag_set_data(self.val_tag, tris, data)
 
-    def _set_tags(self, tags):
+    def __set_tags(self, tags):
         """Set provided tag values on the root set.
 
         Input:
@@ -865,7 +865,7 @@ class IsoVolume(object):
                                          create_if_missing=True)
             self.mb.tag_set_data(tag, rs, tagval)
 
-    def _write_geometry(self, sname, sdir):
+    def __write_geometry(self, sname, sdir):
         """Writes out the geometry stored in memory.
 
         Input:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This tool can be used to generate an isosurface geometry from any 3D mesh
 tagged with scalar values (eg, a Cartesian weight window mesh used for
 Monte Carlo particle transport).
-The tool will create a meshed surface geometry using specified isosurface
+The tool will create a meshed surface geometry (DAGMC-compliant) using specified isosurface
 values.
 
 ## Dependencies:
@@ -14,7 +14,11 @@ values.
 
 ## Installation:
 
-From the source directory, run `pip install . --user`.
+From the source directory, run the following to install:
+
+      pip install . --user
+
+---
 
 ## Python Module Usage
 
@@ -22,9 +26,75 @@ To use, import the Python module with `from IsogeomGenerator import vol`.
 
 ### Steps:
 
-1. Set contour levels with `assign_levels()`, `read_levels()` or `generate_levels()`
-2. Generate the isovolume files using `generate_volumes()`
-3. Create the MOAB geometry with `create_geometry()`
+To generate a full geometry from a starting Cartesian mesh file, run the following steps in order:
+
+1. **Set contour levels values:** This will assign the values that will be used for the isosurface selections
+    in the mesh file. The values can be set using one of three methods:
+
+    * `assign_levels(levels)`: User defines the contour levels to be used as the isosurfaces.
+
+        Input: `levels`, list of floats, list of user-defined values
+
+    * `read_levels(levelfile)`: Read level values from a file. One value per line only.
+
+        Input: `levelfile`, string, relative path to file with level information.
+
+    * `generate_levels(N, minN, maxN, mode='lin')`: Auto-generate evenly-spaced level values between the min and max value.
+
+        Input:
+        * `N`: int or float, number of levels (int) to generate
+            (`'lin'` or `'log'` mode); or the ratio (float) to use to separate
+            levels (`'ratio'` mode).
+        * `minN`: float, minimum level value
+        * `maxN`: float, maximum level value
+        * `mode` (optional): string, options are `'lin'` (default), `'log'`, or `'ratio'`.
+            * `'lin'`: `N` linearly spaced values between `minN` and `maxN`
+            * `'log'`: `N` logarithmically spaced values between `minN` and `maxN`
+            * `ratio`: levels that are spaced by a constant ratio `N`.
+                `minN` will be used as minimum level value and the maximum
+                level value is less than or equal to `maxN`.
+
+2. **Generate the isovolume database:** This step will use the level values assigned
+    in step 1 to create isovolumes in the mesh file using VisIt.
+    Two consecutive level values are used to generate an isovolume in the meshfile
+    and the surface of that volume is exported as a meshed surface. Each isovolume
+    is exported as one file in the database.
+
+    * `generate_volumes(self, filename, data, dbname='/tmp/')`: Creates an STL file for each isovolume. Files are generated in the `dbname` folder.
+
+        Input:
+        * `filename`: string, path to vtk file with the mesh file
+        * `data`: string, name of the data whose values exist on the mesh
+        (will be used to generate the isovolumes)
+        * `dbname`: (optional), string, Absolute path to the folder to store created
+        surface files. Default: a folder called `tmp/` in the current directory.
+
+3. **Create the DAGMC isosurface geometry:**
+
+    * `create_geometry(tag_for_viz=False, norm=1.0, merge_tol=1e-5, dbname='/tmp/', tags=None, sname=None, sdir=None)`:
+    Creates a DAGMC-compliant isosurface geometry from the isovolume files in the database created in step 2 using MOAB.
+
+        Input:
+        * `tag_for_viz`: bool (optional), True to tag each triangle on
+            every surface with the data value. Needed to visualize
+            values in VisIt. Default=False.
+        * `norm`: float (optional), default=1. All ww values will be
+            multiplied by the normalization factor.
+        * `merge_tol`: float (option), default=1e-5 cm. Merge tolerance for
+            mesh based merge of coincident surfaces. Recommended to be
+            1/10th the mesh voxel size.
+        * `dbname`: (optional), string, name of folder to store created
+            surface files. Must be absolute path.
+            default: a folder called 'tmp' in the current directory
+        * `tags`: (optional), dict, set of names and values to tag on the
+            geometry root set. Dictionary should be structured with each
+            key as a tag name (str) and with a single value (float) for the
+            tag. Example: {'NAME1':1.0, 'NAME2': 2.0}
+        * `sname`: (optional), str, name of file (including extension) for the
+            written geometry file. Acceptable file types are VTK and H5M.
+            Default name: isogeom.h5m
+
+----
 
 ## Command Line Tool
 
@@ -32,17 +102,24 @@ The steps for creating an isosurface geometry can be done on the command line
 with the `generate_isogeom` command. This tool can be run in three different
 modes:
 
-* full: this will run both the visit step then the moab step.
-(command: `generate_isogeom full ...`)
-* visit: starting from a Cartesian mesh file, this will generate only a database of
-separate isosurface files from VisIt (step 2 above). (command: `generate_isogeom visit ...`)
-* moab: this will start from the database (generated in the visit step) to create
+* `full`: this will run both the visit step then the moab step (described below). Command:
+
+      generate_isogeom full <meshfile> <dataname> [options]
+
+* `visit`: starting from a Cartesian mesh file, this will generate only a database of
+separate isosurface files from VisIt (step 2 above). Command:
+
+      generate_isogeom visit <meshfile> <dataname> [options]
+
+* `moab`: this will start from the database (generated in the visit step) to create
 a DAGMC-compliant isosurface geometry using PyMOAB (step 3 above).
-(command: `generate_isogeom moab ...`)
+Command:
+
+      generate_isogeom moab [options]
 
 To view the three different modes, run `generate_isogeom --help`.
 
-### Use
+### Options
 Each mode has different required or optional arguments needed at run time.
 Below is a table summary of those options. This information is also available
 via terminal help message: (`generate_isogeom [mode] --help`).
@@ -71,3 +148,25 @@ via terminal help message: (`generate_isogeom [mode] --help`).
 | Isosurface Geometry Filename | `-g`/`--geomfile` `GEOM_FILENAME` | Filename to write generated isosurface geometry file. Must be either a .h5m or .vtk file name. | `isogeom.h5m` | `O` | `-` | `O` |
 | Save Location | `-sp`/`--savepath` `PATH` | Absolue path to folder to write generated geometry file. | Database Path | `O` | `-` | `O` |
 | Extra Tag Information | `-t`/`--tag` `TAGNAME TAGVAL` | Information to tag on the whole geometry. First entry must be the name for the tag (string). Second entry must be the value for the tag (will be tagged as float). Option can be set more than once to set more tags. | | `O` | `-` | `O` |
+
+### Example Usage
+
+All of these examples will assume a starting Cartesian mesh file called `cw_mesh` with the desired data called `wwn`.
+
+(1) Run all the steps start to finish (full mode) starting with meshfile
+        'cw_mesh', scalar data 'wwn', and defining 3 values for the level
+        information at runtime:
+
+        generate_isogeom full cw_mesh wwn -lv 0.1 5.2 12.3
+
+    (2) Run just the first step (visit mode), generating logarithmically spaced
+        levels between 0.1 and 1e+14 and specifying where to write the
+        generated database:
+
+        generate_isogeom visit -gl log -lx 0.1 1e+14 -db my_database/
+
+    (3) Run only the second step (moab mode), using the levelfile and database
+        from the MOAB step, and specifying a file name for file produced:
+
+        generate_isogeom moab -lf my_database/levelfile -db my_database
+            -g geom1.h5m

--- a/README.md
+++ b/README.md
@@ -14,18 +14,14 @@ values.
 
 ## Installation:
 
-From the source directory, run `pip install -e . --user`.
+From the source directory, run `pip install . --user`.
 
-## Usage
+## Python Module Usage
 
-To use, import the Python module with `import IsogeomGenerator`.
-
-Required input file: a 3D mesh file (such as a Cartesian mesh) with scalar
-values defined on each mesh voxel.
+To use, import the Python module with `from IsogeomGenerator import vol`.
 
 ### Steps:
 
-1. Set contour levels with `assign_levels()` or `generate_levels()`
+1. Set contour levels with `assign_levels()`, `read_levels()` or `generate_levels()`
 2. Generate the isovolume files using `generate_volumes()`
 3. Create the MOAB geometry with `create_geometry()`
-4. Write to a file with `write_geometry()`

--- a/README.md
+++ b/README.md
@@ -46,10 +46,26 @@ Each mode has different required or optional arguments needed at run time.
 Below is a table summary of those options. This information is also available
 via terminal help message: (`generate_isogeom [mode] --help`).
 
-    | Option                      |        Mode         |
-    |-----------------------------|---------------------|
-    | Name     | Description      | Full | Visit | MOAB |
-    |----------|------------------|---------------------|
-    | meshfile |    tmp           |  X   |   X   |      |
-    |          | long description |      |       |      |
-    |----------|------------------|------|-------|------|
+* `X` = required
+* `O` = optional
+* `-` = Not allowed
+
+|||||| Mode ||
+|------|
+| | Option | Description | Default value | full | visit | moab |
+| Mesh file information |||||||
+| |`meshfile` ||| `X` | `X` | `-` |
+| |`dataname` ||| `X` | `X` | `-` |
+| Level value information | One of the following options is required: `-lf`, `-lv`, `-gl` | | | `X` | `X` | `X` |
+| | `-lf/--levelfile LEVELFILE` | | | `O` | `O` | `O` |
+| | `-lv/--levelvalues VAL [VAL VAL]` | | | `O` | `O` | `O` |
+| | `-gl/--generatelevels ratio/log/lin` | | | `O` | `O` | `-` |
+| | `-N/--numlevels N` | (Required if using `-gl`, otherwise not allowed) | | `X`/`-` | `X`/`-` | `-` |
+| | `-lx/-levelextrema MIN_VAL MAX_VAL` | (Required if using `-gl`, otherwise not allowed) | | `X`/`-` | `X`/`-` | `-` |
+| Geometry Information | | | | | | |
+| | `-db/--database DATABASE_PATH` | | | `O` | `O` | `O` |
+| | `-m/--mergetol TOL` | | | `O` | `-` | `O` |
+| | `-n/--norm NORM_FACTOR` | | | `O` | `-` | `O` |
+| | `-v/--viz` | | | `O` | `-` | `O` |
+| | `-g/--geomfile GEOM_FILENAME` | | | `O` | `-` | `O` |
+| | `-sp/--savepath PATH` | | | `O` | `-` | `O` |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ a DAGMC-compliant isosurface geometry using PyMOAB (step 3 above).
 
 To view the three different modes, run `generate_isogeom --help`.
 
+### Use
 Each mode has different required or optional arguments needed at run time.
 Below is a table summary of those options. This information is also available
 via terminal help message: (`generate_isogeom [mode] --help`).
@@ -50,22 +51,23 @@ via terminal help message: (`generate_isogeom [mode] --help`).
 * `O` = optional
 * `-` = Not allowed
 
-| | | | | | Mode | |
-|-|-|-|-|-|------|-|
-| | Option | Description | Default value | full | visit | moab |
-| Mesh file information |||||||
-| |`meshfile` ||| `X` | `X` | `-` |
-| |`dataname` ||| `X` | `X` | `-` |
-| Level value information | One of the following options is required: `-lf`, `-lv`, `-gl` | | | `X` | `X` | `X` |
-| | `-lf/--levelfile LEVELFILE` | | | `O` | `O` | `O` |
-| | `-lv/--levelvalues VAL [VAL VAL]` | | | `O` | `O` | `O` |
-| | `-gl/--generatelevels ratio/log/lin` | | | `O` | `O` | `-` |
-| | `-N/--numlevels N` | (Required if using `-gl`, otherwise not allowed) | | `X`/`-` | `X`/`-` | `-` |
-| | `-lx/-levelextrema MIN_VAL MAX_VAL` | (Required if using `-gl`, otherwise not allowed) | | `X`/`-` | `X`/`-` | `-` |
-| Geometry Information | | | | | | |
-| | `-db/--database DATABASE_PATH` | | | `O` | `O` | `O` |
-| | `-m/--mergetol TOL` | | | `O` | `-` | `O` |
-| | `-n/--norm NORM_FACTOR` | | | `O` | `-` | `O` |
-| | `-v/--viz` | | | `O` | `-` | `O` |
-| | `-g/--geomfile GEOM_FILENAME` | | | `O` | `-` | `O` |
-| | `-sp/--savepath PATH` | | | `O` | `-` | `O` |
+|_**Command Option**_ | | | | _**Run Mode**_ | | |
+|-|-|-|-|-|----------|-|
+| | **Option** | **Description** | **Default value** | `full` | `visit` | `moab` |
+| *Mesh file information* | | | | | | |
+| Cartesian Mesh File |`meshfile` | Relative path to the Cartesian mesh file that will be used to generate isosurfaces. | | `X` | `X` | `-` |
+| Data Name |`dataname` | The name of the scalar data on the Cartesian mesh file to use for the isosurfaces. | | `X` | `X` | `-` |
+| *Level value information* | _One of the following options is required: `-lf`, `-lv`, `-gl`_ | _These options set the values that will be used for the isosurfaces in the mesh file._ | | `X` | `X` | `X` |
+| Level File | `-lf`/`--levelfile` `LEVELFILE` | Relative path to file containing values to use for isosurface levels. File should be structured to have one value per line. | | `O` | `O` | `O` |
+| Level Values | `-lv`/`--levelvalues` `VAL [VAL VAL]` | List of values used to generate isosurfaces in VisIt. | | `O` | `O` | `O` |
+| Generate Levels | `-gl`/`--generatelevels` `ratio`/`log`/`lin` |  Specifies the mode for generating level values to be used for the isosurfaces. If used, values for the minimum and maximum levels (`-lx`) and the ratio or number of levels (`-N`) are also required. Options are: (1) `ratio`: `N` is the ratio between levels ranging from the min value up to, but not exceeding, the max value. (2) `log`: `N` is the number of levels to be evenly spaced logarithmically between the min and max values. (3) `lin`: `N` is the number of levels to be evenly spaced linearly between the min and max values. | | `O` | `O` | `-` |
+| Number of Levels | `-N`/`--numlevels` `N` | (Required if using `-gl`, otherwise not allowed) | | `X`/`-` | `X`/`-` | `-` |
+| Level Min/Max| `-lx`/`--levelextrema` `MIN_VAL MAX_VAL` | (Required if using `-gl`, otherwise not allowed) | | `X`/`-` | `X`/`-` | `-` |
+| *Geometry information* | | _These options specify information needed to generate a DAGMC geometry from the isosurfaces produced from VisIt._ | | | | |
+| Database Path | `-db`/`--database` `DATABASE_PATH` | Relative path to folder where isosurface meshfiles from VisIt are to be saved (`visit` step) or read from (`moab` step). | A folder called `tmp/` in the current directory: `${PWD}/tmp/` | `O` | `O` | `O` |
+| Mesh-based Merge Tolerance | `-m`/`--mergetol` `TOL` | Merge tolerance for mesh based merging of coincident surfaces. | `1e-5` | `O` | `-` | `O` |
+| Surface Normalization Factor | `-n`/`--norm` `NORM_FACTOR` |  All level values will be multiplied by this normalization factor when the geometry is generated. | `1.0` | `O` | `-` | `O` |
+| Visualization Tag | `-v`/`--viz` | If set, surfaces generated will be tagged with data for visualization purposes in VisIt. Note: this will increase the file size as each individual facet will be tagged with data. | | `O` | `-` | `O` |
+| Isosurface Geometry Filename | `-g`/`--geomfile` `GEOM_FILENAME` | Filename to write generated isosurface geometry file. Must be either a .h5m or .vtk file name. | `isogeom.h5m` | `O` | `-` | `O` |
+| Save Location | `-sp`/`--savepath` `PATH` | Absolue path to folder to write generated geometry file. | Database Path | `O` | `-` | `O` |
+| Extra Tag Information | `-t`/`--tag` `TAGNAME TAGVAL` | Information to tag on the whole geometry. First entry must be the name for the tag (string). Second entry must be the value for the tag (will be tagged as float). Option can be set more than once to set more tags. | | `O` | `-` | `O` |

--- a/README.md
+++ b/README.md
@@ -81,18 +81,17 @@ To generate a full geometry from a starting Cartesian mesh file, run the followi
         * `norm`: float (optional), default=1. All data values will be
             multiplied by the normalization factor.
         * `merge_tol`: float (option), default=1e-5 cm. Merge tolerance for
-            mesh based merge of coincident surfaces. Recommended to be
-            1/10th the mesh voxel size.
-        * `dbname`: (optional), string, name of folder to store created
+            mesh based merge of coincident surfaces.
+        * `dbname`: string (optional), name of folder to store created
             surface files. Must be absolute path.
             default: a folder called 'tmp' in the current directory
-        * `tags`: (optional), dict, set of names and values to tag on the
+        * `tags`: dict (optional), set of names and values to tag on the
             geometry root set. Dictionary should be structured with each
             key as a tag name (str) and with a single value (float) for the
-            tag. Example: {'NAME1':1.0, 'NAME2': 2.0}
-        * `sname`: (optional), str, name of file (including extension) for the
+            tag. Example: `{'NAME1':1.0, 'NAME2': 2.0}`
+        * `sname`: string (optional), name of file (including extension) for the
             written geometry file. Acceptable file types are VTK and H5M.
-            Default name: isogeom.h5m
+            Default name: `isogeom.h5m`
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This tool can be used to generate an isosurface geometry from any 3D mesh
 tagged with scalar values (eg, a Cartesian weight window mesh used for
 Monte Carlo particle transport).
-The tool will create a meshed surface geometry (DAGMC-compliant) using specified isosurface
+The tool will create a meshed surface geometry ([DAGMC](https://svalinn.github.io/DAGMC/)-compliant) using specified isosurface
 values.
 
 ## Dependencies:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To generate a full geometry from a starting Cartesian mesh file, run the followi
         * `tag_for_viz`: bool (optional), True to tag each triangle on
             every surface with the data value. Needed to visualize
             values in VisIt. Default=False.
-        * `norm`: float (optional), default=1. All ww values will be
+        * `norm`: float (optional), default=1. All data values will be
             multiplied by the normalization factor.
         * `merge_tol`: float (option), default=1e-5 cm. Merge tolerance for
             mesh based merge of coincident surfaces. Recommended to be

--- a/README.md
+++ b/README.md
@@ -25,3 +25,31 @@ To use, import the Python module with `from IsogeomGenerator import vol`.
 1. Set contour levels with `assign_levels()`, `read_levels()` or `generate_levels()`
 2. Generate the isovolume files using `generate_volumes()`
 3. Create the MOAB geometry with `create_geometry()`
+
+## Command Line Tool
+
+The steps for creating an isosurface geometry can be done on the command line
+with the `generate_isogeom` command. This tool can be run in three different
+modes:
+
+* full: this will run both the visit step then the moab step.
+(command: `generate_isogeom full ...`)
+* visit: starting from a Cartesian mesh file, this will generate only a database of
+separate isosurface files from VisIt (step 2 above). (command: `generate_isogeom visit ...`)
+* moab: this will start from the database (generated in the visit step) to create
+a DAGMC-compliant isosurface geometry using PyMOAB (step 3 above).
+(command: `generate_isogeom moab ...`)
+
+To view the three different modes, run `generate_isogeom --help`.
+
+Each mode has different required or optional arguments needed at run time.
+Below is a table summary of those options. This information is also available
+via terminal help message: (`generate_isogeom [mode] --help`).
+
+    | Option                      |        Mode         |
+    |-----------------------------|---------------------|
+    | Name     | Description      | Full | Visit | MOAB |
+    |----------|------------------|---------------------|
+    | meshfile |    tmp           |  X   |   X   |      |
+    |          | long description |      |       |      |
+    |----------|------------------|------|-------|------|

--- a/README.md
+++ b/README.md
@@ -152,20 +152,26 @@ via terminal help message: (`generate_isogeom [mode] --help`).
 
 All of these examples will assume a starting Cartesian mesh file called `cw_mesh` with the desired data called `wwn`.
 
-(1) Run all the steps start to finish (full mode) starting with meshfile
-        'cw_mesh', scalar data 'wwn', and defining 3 values for the level
-        information at runtime:
+* Run all the steps start to finish, defining 3 values for the level information at runtime, and tag for visualization:
 
-        generate_isogeom full cw_mesh wwn -lv 0.1 5.2 12.3
+      generate_isogeom full cw_mesh wwn -lv 0.1 5.2 12.3 --viz
 
-    (2) Run just the first step (visit mode), generating logarithmically spaced
-        levels between 0.1 and 1e+14 and specifying where to write the
-        generated database:
+* Generate a geometry start to finish, with 5 levels logarithmically spaced from 1e-5 to 1e+3. Also tag the geometry two metadata tags called E1 and E2 with values of 1.0 and 10.0, respectively:
 
-        generate_isogeom visit -gl log -lx 0.1 1e+14 -db my_database/
+      generate_isogeom full meshfile my_data -gl log -lx 1e-5 1e+3 -N 5 -t E1 1.0 -t E2 10.0
 
-    (3) Run only the second step (moab mode), using the levelfile and database
-        from the MOAB step, and specifying a file name for file produced:
+* Generate only the isovolume database using levels that logarithmically spaced between 0.1 and 1e+14 and specifying where to write the generated database:
 
-        generate_isogeom moab -lf my_database/levelfile -db my_database
-            -g geom1.h5m
+      generate_isogeom visit cw_mesh wwn -gl log -lx 0.1 1e+14 -db my_database/
+
+* Generate an isovolume database in the default location using levels between 1.0 2e+4 that are spaced with a ratio of 20:
+
+      generate_isogeom visit cw_mesh wwn -gl ratio -lx 1.0 2.e4 -N 20
+
+* Generate an isosurface geometry using the levelfile and database located in my_database/, specifying a file name for file produced:
+
+      generate_isogeom moab -lf my_database/levelfile -db my_database -g geom1.h5m
+
+* Generate a geometry from a database located in 'my_isogeom/', read the level info from a file called 'levelinfo', mutliply all data by a factor of 2e4, and save the file as 'my_isogeom.vtk' in a new folder called 'output_folder/':
+
+      generate_isogeom moab -db my_isogeom/ -lf levelinfo -n 2e4 -g my_isogeom.vtk -sp output_folder/

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ All of these examples will assume a starting Cartesian mesh file called `cw_mesh
 
 * Generate a geometry start to finish, with 5 levels logarithmically spaced from 1e-5 to 1e+3. Also tag the geometry two metadata tags called E1 and E2 with values of 1.0 and 10.0, respectively:
 
-      generate_isogeom full meshfile my_data -gl log -lx 1e-5 1e+3 -N 5 -t E1 1.0 -t E2 10.0
+      generate_isogeom full cw_mesh wwn -gl log -lx 1e-5 1e+3 -N 5 -t E1 1.0 -t E2 10.0
 
 * Generate only the isovolume database using levels that logarithmically spaced between 0.1 and 1e+14 and specifying where to write the generated database:
 
@@ -172,6 +172,6 @@ All of these examples will assume a starting Cartesian mesh file called `cw_mesh
 
       generate_isogeom moab -lf my_database/levelfile -db my_database -g geom1.h5m
 
-* Generate a geometry from a database located in 'my_isogeom/', read the level info from a file called 'levelinfo', mutliply all data by a factor of 2e4, and save the file as 'my_isogeom.vtk' in a new folder called 'output_folder/':
+* Generate a geometry from a database located in `my_isogeom/`, read the level info from a file called `levelinfo`, mutliply all data by a factor of 2e4, and save the file as `my_isogeom.vtk` in a new folder called `output_folder/`:
 
       generate_isogeom moab -db my_isogeom/ -lf levelinfo -n 2e4 -g my_isogeom.vtk -sp output_folder/

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ via terminal help message: (`generate_isogeom [mode] --help`).
 * `O` = optional
 * `-` = Not allowed
 
-|||||| Mode ||
-|------|
+| | | | | | Mode | |
+|-|-|-|-|-|------|-|
 | | Option | Description | Default value | full | visit | moab |
 | Mesh file information |||||||
 | |`meshfile` ||| `X` | `X` | `-` |

--- a/README.md
+++ b/README.md
@@ -6,13 +6,22 @@ Monte Carlo particle transport).
 The tool will create a meshed surface geometry ([DAGMC](https://svalinn.github.io/DAGMC/)-compliant) using specified isosurface
 values.
 
-## Dependencies:
+## Table of Contents
+
+1. [Installation](#Installation)
+2. [Python Module](#Python-Module-Usage)
+3. [Command Line Tool](#Command-Line-Tool)
+-----
+
+## Installation
+
+### Dependencies:
 
 * Python 2.7
 * [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit/)
 * [MOAB](https://sigma.mcs.anl.gov/moab-library/) v5.1+ with PyMOAB enabled
 
-## Installation:
+### Pip install:
 
 From the source directory, run the following to install:
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ values.
 
 ## Installation
 
-### Dependencies:
+### Dependencies
 
 * Python 2.7
 * [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit/)
 * [MOAB](https://sigma.mcs.anl.gov/moab-library/) v5.1+ with PyMOAB enabled
 
-### Pip install:
+### Pip install
 
 From the source directory, run the following to install:
 
@@ -33,7 +33,7 @@ From the source directory, run the following to install:
 
 To use, import the Python module with `from IsogeomGenerator import vol`.
 
-### Steps:
+### Steps
 
 To generate a full geometry from a starting Cartesian mesh file, run the following steps in order:
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/kkiesling/IsogeomGenerator",
     packages=setuptools.find_packages(),
-    entry_points = {
-        'console_scripts': ['generate_isogeom=IsogeomGenerator.generate_isogeom:main']}
+    entry_points={
+        'console_scripts':
+        ['generate_isogeom=IsogeomGenerator.generate_isogeom:main']}
 )

--- a/tests/test_vol.py
+++ b/tests/test_vol.py
@@ -13,7 +13,6 @@ class TestIsogeom(unittest.TestCase):
         v.assign_levels(levels)
         assert(v.levels == exp)
 
-
     def test_generate_levels_linear(self):
         """generate linearly spaced levels"""
         v = vol.IsoVolume()
@@ -24,7 +23,6 @@ class TestIsogeom(unittest.TestCase):
 
         v.generate_levels(N, minN, maxN, log=False)
         assert(v.levels == exp)
-
 
     def test_generate_levels_log(self):
         """generate lograthmically spaced levels"""
@@ -47,7 +45,6 @@ class TestIsogeom(unittest.TestCase):
 
         v.generate_levels(N, minN, maxN, ratio=True)
         assert(v.levels == exp)
-
 
     def test_generate_levels_ratio_2(self):
         """generate levels by ratio, max not included"""

--- a/tests/test_vol.py
+++ b/tests/test_vol.py
@@ -21,7 +21,7 @@ class TestIsogeom(unittest.TestCase):
         maxN = 15
         exp = [5., 7., 9., 11., 13., 15.]
 
-        v.generate_levels(N, minN, maxN, log=False)
+        v.generate_levels(N, minN, maxN, mode='lin')
         assert(v.levels == exp)
 
     def test_generate_levels_log(self):
@@ -32,7 +32,7 @@ class TestIsogeom(unittest.TestCase):
         maxN = 1e5
         exp = [1., 10., 1.e2, 1.e3, 1.e4, 1.e5]
 
-        v.generate_levels(N, minN, maxN, log=True)
+        v.generate_levels(N, minN, maxN, mode='log')
         assert(v.levels == exp)
 
     def test_generate_levels_ratio_1(self):
@@ -43,7 +43,7 @@ class TestIsogeom(unittest.TestCase):
         maxN = 625
         exp = [1., 5., 25., 125., 625.]
 
-        v.generate_levels(N, minN, maxN, ratio=True)
+        v.generate_levels(N, minN, maxN, mode='ratio')
         assert(v.levels == exp)
 
     def test_generate_levels_ratio_2(self):
@@ -54,5 +54,5 @@ class TestIsogeom(unittest.TestCase):
         maxN = 700
         exp = [1., 5., 25., 125., 625.]
 
-        v.generate_levels(N, minN, maxN, ratio=True)
+        v.generate_levels(N, minN, maxN, mode='ratio')
         assert(v.levels == exp)


### PR DESCRIPTION
To make this whole tools more accessible, I created a command-line tool that a user can use to generate an isosurface geometry. The file with all this in it is `generate_isogeom.py`. I also made some minor changes to the actual class with all the heavy lifting (mainly PEP8 changes but also some necessary changes for the user script).

For this PR, I am looking for someone to review the `generate_isogeom.py` file and let me know if there are questions on the parser help messages or if it is clear how to use it based on the parser documentation. The parser should be set up to have three subparsers depending on the mode the user chooses. You can test out the three modes with the these commands and try out some of the optional arguments (without real files though, nothing will run properly, but you can at least play around with the parser):
* `generate_isogeom --help`
* `generate_isogeom full --help`
* `generate_isogeom visit --help`
* `generate_isogeom moab --help`

You may have to install with `pip install . --user`

Note: README still needs updated and the `vol.py` file still needs some major updates/refactoring and there are no tests yet. This will all come in different future PRs.